### PR TITLE
v0.17.0 — a tmux watchdog, and revive that survives losing the server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "source": "./",
       "displayName": "Fleet Deck",
       "description": "Localhost fleet board for Claude Code: every session on the machine visible on one board, cross-session file-conflict whispers, and turn-boundary mail between sessions. Zero wrapper, zero model calls in the core. Tested against Claude Code 2.1.206+ (through 2.1.207).",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "author": {
         "name": "Luis Morales"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck",
   "displayName": "Fleet Deck",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Localhost fleet board for Claude Code: every session on the machine visible on one board, cross-session file-conflict whispers, and turn-boundary mail between sessions. Zero wrapper, zero model calls in the core. Tested against Claude Code 2.1.206+ (through 2.1.207).",
   "author": {
     "name": "Luis Morales",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to Fleet Deck are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-07-22
+
+Losing the tmux server took the whole board with it — silently, and then
+permanently. Every spawn vanished at once with nothing said about why, and from
+then on ⟲ revive answered `503 tmux window lookup failed; revive held to avoid a
+duplicate session` forever, with no way back except starting a tmux server by
+hand. This release makes that survivable: Fleet Deck now watches the tmux server
+it depends on, says plainly when it dies, settles the sessions that went down
+with it so they can be revived, and stands a fresh server back up.
+
+### Added
+
+- **A tmux server watchdog.** The liveness tick was the only thing watching
+  tmux and it watched in silence, so losing the tmux server looked like every
+  spawn dying at once for no stated reason. Per-window absence is deliberately
+  UNKNOWN at runtime — right for one window, wrong for the whole server — which
+  meant a SIGKILLed tmux left every row `live` forever: the board kept showing
+  panes that no longer existed and ⟲ revive answered `409 spawn is live, not
+  revivable`, with no way for a human to say "it's dead, bring it back". The
+  tick now asks the one question that separates a healthy-but-empty server from
+  a dead one, and acts only on proof (a death certificate plus tmux's own
+  absence verdict — a pane cannot outlive the server that ran it):
+  - the loss is announced once — `💀 the tmux server died — N spawn(s) went
+    with it; ⟲ revive brings them back`;
+  - the rows it took down are settled to `gone`, so Revive is offered instead
+    of a 409, and their cards go offline with a `claude --resume` note;
+  - a fresh fleet session is stood back up, so the board is usable again and
+    the next Revive lands on a live server.
+
+  It never relaunches an agent: resuming one spends money, so that decision
+  stays with the human. A tmux that merely stops answering is reported too
+  (`⚠ tmux is not answering — holding every card as-is until it does`, once,
+  after three consecutive failures, with a matching recovery line) and still
+  condemns nothing.
+
+### Fixed
+
+- **Revive no longer wedges permanently when the tmux server dies.** Losing the
+  tmux server took the whole board with it: every later Revive, Adopt and `/rc`
+  answered `503 tmux window lookup failed; revive held to avoid a duplicate
+  session`, forever, with no way back except starting a tmux server by hand.
+  Proving the recorded owner dead (ESRCH) is what proves its panes died with it
+  — and retiring the claim *destroyed that proof at the instant it was
+  obtained*, so exactly one call could answer "empty" and every call after it
+  went back to UNKNOWN. The liveness tick consumed that single recovery seconds
+  after the crash, and the refusal could not heal, because those three callers
+  ask "is this window free?" *before* the only code that ever creates a tmux
+  server. The proof is now kept as a death certificate
+  (`tmux-generation-<port>.retired`) that outlives the claim it replaced and is
+  cleared by the next successful claim, so absence is a stable answer and the
+  fleet comes back on the first click. A home that never claimed a server still
+  reports UNKNOWN — with no certificate there is no evidence, and a silent
+  socket is exactly what a live server behind an unlinked socket looks like.
+- **A failed tmux probe is no longer mistaken for an empty fleet.** Only tmux's
+  own two absence verdicts (`no server running on …`, `error connecting to …
+  (No such file or directory)`) count as proof that nothing is listening. A
+  timeout, a shadowed or missing `tmux` binary, an unreadable socket directory
+  or fork exhaustion stays UNKNOWN and fails closed — previously any of them
+  could have told boot reconciliation that a board full of live panes was gone.
+- **`ensureSession` can no longer report success without a tmux server.**
+  `has-session` is a predicate, so an authoritatively-empty short circuit
+  (correct for a listing: there is nothing to list) must not be read as "the
+  session exists".
+
 ## [0.16.1] - 2026-07-22
 
 0.16.0's loopback power gates assumed someone saw the daemon print its
@@ -385,6 +449,9 @@ Initial public release.
 - A brainless orchestrator: `assign auto` routes a task to the best existing session with a SQL query, not a model call — the core makes zero model calls.
 - One-command plugin install with a self-contained daemon bundle (`node:sqlite` state, nothing to `npm install`); the first session's SessionStart hook elects and launches the daemon. MIT licensed.
 
+[0.17.0]: https://github.com/lacion/fleet-deck/compare/v0.16.1...v0.17.0
+[0.16.1]: https://github.com/lacion/fleet-deck/compare/v0.16.0...v0.16.1
+[0.16.0]: https://github.com/lacion/fleet-deck/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/lacion/fleet-deck/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/lacion/fleet-deck/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/lacion/fleet-deck/compare/v0.12.0...v0.13.0

--- a/board/package-lock.json
+++ b/board/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetdeck-board",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetdeck-board",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/board/package.json
+++ b/board/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck-board",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.17.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetdeck",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Fleet Deck — localhost daemon + board that makes every Claude Code session on a machine visible. Tested against Claude Code 2.1.206.",
   "type": "module",
   "license": "MIT",

--- a/scripts/fleetd/fleetd.bundle.mjs
+++ b/scripts/fleetd/fleetd.bundle.mjs
@@ -4549,6 +4549,7 @@ __export(spawn_exports, {
   capturePane: () => capturePane,
   ensureSession: () => ensureSession,
   exactWindowTarget: () => exactWindowTarget,
+  fleetServerAbsent: () => fleetServerAbsent,
   hasTmux: () => hasTmux,
   killWindowVerified: () => killWindowVerified,
   launchOverride: () => launchOverride,
@@ -4679,6 +4680,7 @@ function generationPort(port) {
 }
 var generationOption = (port) => `@fleetdeck_generation_${generationPort(port)}`;
 var generationFile = (home, port) => path2.join(home, `tmux-generation-${generationPort(port)}`);
+var retiredGenerationFile = (home, port) => `${generationFile(home, port)}.retired`;
 function generationHome() {
   const home = process.env.FLEETDECK_HOME?.trim();
   return home || null;
@@ -4777,18 +4779,27 @@ async function replacePersistedGeneration(home, port, record) {
   }
   return readPersistedGeneration(home, port);
 }
+var SERVER_ABSENT_RE = /(?:^|\n)(?:no server running on |error connecting to .*\(No such file or directory\))/i;
 async function readServerGeneration(port) {
   const result = await tmuxResult([
     "display-message",
     "-p",
     `#{${generationOption(port)}}${FIELD_SEP}#{pid}`
   ], { noStart: true });
-  if (!result.ok) return { reachable: false, generation: null, serverPid: null };
+  if (!result.ok) {
+    return {
+      reachable: false,
+      absent: SERVER_ABSENT_RE.test(String(result.error ?? "")),
+      generation: null,
+      serverPid: null
+    };
+  }
   const value = result.out.endsWith("\n") ? result.out.slice(0, -1) : result.out;
   const [generation, pidText, ...extra] = value.split(FIELD_SEP);
   const serverPid = Number(pidText);
   return {
     reachable: true,
+    absent: false,
     generation: GENERATION_UUID_RE.test(generation) ? generation.toLowerCase() : null,
     serverPid: extra.length === 0 && Number.isSafeInteger(serverPid) && serverPid > 1 ? serverPid : null
   };
@@ -4804,10 +4815,68 @@ function pidState(pid) {
   }
 }
 var sameRecord = (left, right) => !!left && !!right && left.generation === right.generation && left.serverPid === right.serverPid;
+async function recordRetiredGeneration(home, port, expected) {
+  const file = retiredGenerationFile(home, port);
+  const temp = path2.join(home, `.${path2.basename(file)}.${process.pid}.${randomUUID()}.tmp`);
+  let handle;
+  try {
+    handle = await open(temp, "wx", 384);
+    await handle.writeFile(`${JSON.stringify({
+      retiredGeneration: expected.generation,
+      retiredServerPid: expected.serverPid
+    })}
+`, "utf8");
+    await handle.chmod(384);
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await rename(temp, file);
+  } catch (err) {
+    throw new Error(`cannot record retired tmux generation (${err?.code || err?.message || err})`);
+  } finally {
+    try {
+      await handle?.close();
+    } catch {
+    }
+    try {
+      await unlink(temp);
+    } catch (err) {
+      if (err?.code !== "ENOENT") {
+      }
+    }
+  }
+}
+async function hasRetiredGeneration(home, port) {
+  let handle;
+  try {
+    handle = await open(retiredGenerationFile(home, port), fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+  } catch {
+    return false;
+  }
+  try {
+    return (await handle.stat()).isFile();
+  } catch {
+    return false;
+  } finally {
+    try {
+      await handle.close();
+    } catch {
+    }
+  }
+}
+async function clearRetiredGeneration(home, port) {
+  try {
+    await unlink(retiredGenerationFile(home, port));
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+    }
+  }
+}
 async function retireDeadGeneration(home, port, expected) {
   if (expected.serverPid === null || pidState(expected.serverPid) !== "dead") return false;
   const current = await readPersistedGeneration(home, port);
   if (!sameRecord(current, expected) || pidState(expected.serverPid) !== "dead") return false;
+  await recordRetiredGeneration(home, port, expected);
   try {
     await unlink(generationFile(home, port));
     return true;
@@ -4838,14 +4907,14 @@ async function prepareServerGenerationUnlocked(home, port) {
     if (expected.serverPid !== null && await retireDeadGeneration(home, port, expected)) {
       expected = null;
       server2 = await readServerGeneration(port);
-      if (!server2.reachable) {
-        return { enabled: true, expected: null, verified: false, authoritativeEmpty: true };
-      }
     } else {
       return { enabled: true, expected, verified: false };
     }
   }
   if (!server2.reachable) {
+    if (server2.absent && await hasRetiredGeneration(home, port)) {
+      return { enabled: true, expected: null, verified: false, authoritativeEmpty: true };
+    }
     return { enabled: true, expected: null, verified: false };
   }
   if (server2.generation === null) {
@@ -4862,6 +4931,7 @@ async function prepareServerGenerationUnlocked(home, port) {
     generation: server2.generation,
     serverPid: server2.serverPid
   });
+  await clearRetiredGeneration(home, port);
   server2 = await readServerGeneration(port);
   return {
     enabled: true,
@@ -4909,6 +4979,14 @@ async function generationVerifiedResult(port, args) {
   }
   return { ok: true, out: result.out.slice(newline + 1), generation: state.expected.generation };
 }
+async function fleetServerAbsent(port) {
+  try {
+    const state = await prepareServerGeneration(port);
+    return state.enabled === true && state.authoritativeEmpty === true;
+  } catch {
+    return false;
+  }
+}
 var probe = { available: false, reason: `tmux ${MIN_TMUX_VERSION}+ required`, at: 0 };
 var PROBE_TTL_MS = 6e4;
 function hasTmux() {
@@ -4949,6 +5027,7 @@ function exactTargetPort(target) {
   const match = /^=fleetdeck-(\d+):=fd(\d+)-[A-Za-z0-9-]+$/.exec(String(target));
   return match && match[1] === match[2] ? match[1] : null;
 }
+var sessionConfirmed = (result) => result.ok && !result.authoritativeEmpty;
 async function ensureSession(port) {
   const name = sessionName(port);
   const state = await prepareServerGeneration(port);
@@ -4964,7 +5043,7 @@ async function ensureSession(port) {
       const claimed = await prepareServerGeneration(port);
       if (claimed.verified) {
         const confirmed = await generationVerifiedResult(port, ["has-session", "-t", "=" + name]);
-        if (confirmed.ok) return name;
+        if (sessionConfirmed(confirmed)) return name;
       }
       throw new Error(`tmux server generation could not be claimed for ${name}`);
     }
@@ -4972,7 +5051,7 @@ async function ensureSession(port) {
     throw new Error(`tmux server generation unavailable or changed for ${name}`);
   }
   const existing = await generationVerifiedResult(port, ["has-session", "-t", "=" + name]);
-  if (existing.ok) return name;
+  if (sessionConfirmed(existing)) return name;
   const refreshed = await prepareServerGeneration(port);
   if (!refreshed.verified || refreshed.expected === null) {
     throw new Error(`tmux server generation unavailable or changed for ${name}`);
@@ -4986,10 +5065,10 @@ async function ensureSession(port) {
   ], { noStart: true });
   if (created.ok && created.out === "") {
     const confirmed = await generationVerifiedResult(port, ["has-session", "-t", "=" + name]);
-    if (confirmed.ok) return name;
+    if (sessionConfirmed(confirmed)) return name;
   }
   const raced = await generationVerifiedResult(port, ["has-session", "-t", "=" + name]);
-  if (raced.ok) return name;
+  if (sessionConfirmed(raced)) return name;
   throw new Error(`tmux could not create session ${name}`);
 }
 async function newWindow({ port, callsign, cwd, argv, env = null }) {
@@ -9072,12 +9151,55 @@ function createSpawns(ctx) {
     return { status: 200, body: { ok: true, spawn_id, status: "killed" } };
   }
   const CONDEMN_DEAD_READS = 2;
+  const TMUX_UNREACHABLE_READS = 3;
+  const tmuxWatchdog = { unreachableStreak: 0, announcedUnreachable: false };
+  function noteTmuxUnreachable() {
+    if (tmuxAdapter.spawnOverrideCmd?.() || tmuxAdapter.hasTmux?.() === false) return;
+    tmuxWatchdog.unreachableStreak += 1;
+    if (tmuxWatchdog.announcedUnreachable) return;
+    if (tmuxWatchdog.unreachableStreak < TMUX_UNREACHABLE_READS) return;
+    tmuxWatchdog.announcedUnreachable = true;
+    tick("\u26A0 tmux is not answering \u2014 holding every card as-is until it does");
+  }
+  async function mournFleetServer(rows) {
+    tick(`\u{1F480} the tmux server died \u2014 ${rows.length} spawn(s) went with it; \u27F2 revive brings them back`);
+    for (const row of rows) {
+      q.setSpawnStatus.run("gone", row.spawn_id);
+      forgetSpawn(row.spawn_id);
+      const c = q.getSession.get(row.session_id);
+      if (c && c.ended_at == null) {
+        tombstoneCard(row.session_id, {
+          note: `tmux server died \u2014 resume with claude --resume ${row.session_id}`
+        });
+      }
+      logEvent(row.session_id, "SpawnGone", null, "tmux server died");
+    }
+    onMutate();
+    try {
+      await tmuxAdapter.ensureSession(port);
+      tick("\u27F2 tmux server restarted \u2014 the fleet is ready to revive");
+    } catch (err) {
+      tick(`\u26A0 could not restart the tmux server (${String(err?.message || err).slice(0, 80)})`);
+    }
+  }
   async function spawnLivenessTick() {
     const rows = q.activeSpawns.all();
     const resurrectable = q.resurrectableSpawns.all();
     if (!rows.length && !resurrectable.length && !spawnState.orphans.length) return;
     const wins = await tmuxAdapter.listScopedWindows(port);
-    if (wins === null) return;
+    if (wins === null) {
+      noteTmuxUnreachable();
+      return;
+    }
+    tmuxWatchdog.unreachableStreak = 0;
+    if (tmuxWatchdog.announcedUnreachable) {
+      tmuxWatchdog.announcedUnreachable = false;
+      tick("\u2713 tmux is answering again");
+    }
+    if (!wins.length && rows.length && await tmuxAdapter.fleetServerAbsent?.(port)) {
+      await mournFleetServer(rows);
+      return;
+    }
     for (const row of rows) {
       const win = wins.find((w) => w.window === row.tmux_window);
       if (!win) continue;

--- a/scripts/fleetd/spawn.mjs
+++ b/scripts/fleetd/spawn.mjs
@@ -86,6 +86,15 @@ function generationPort(port) {
 
 const generationOption = port => `@fleetdeck_generation_${generationPort(port)}`;
 const generationFile = (home, port) => path.join(home, `tmux-generation-${generationPort(port)}`);
+// The DEATH CERTIFICATE for a retired claim, kept beside it. Proving an owner
+// dead by ESRCH is the only evidence that its panes died with it, and unlinking
+// the claim used to destroy that evidence at the instant it was obtained: the
+// retiring call could answer "authoritatively empty" and every call after it was
+// back to UNKNOWN. Recording the proof instead makes absence a STABLE answer, so
+// revive/adopt/rc keep working rather than wedging until a human starts a tmux
+// server by hand. Kept in its own file so claiming a replacement server still
+// uses the first-writer-wins link() publish on the claim path, untouched.
+const retiredGenerationFile = (home, port) => `${generationFile(home, port)}.retired`;
 
 function generationHome() {
   const home = process.env.FLEETDECK_HOME?.trim();
@@ -181,6 +190,18 @@ async function replacePersistedGeneration(home, port, record) {
   return readPersistedGeneration(home, port);
 }
 
+// Absence has to be PROVEN, never inferred from a probe that merely failed.
+// tmux has exactly two verdicts that mean "nothing is listening here": a socket
+// file with no listener behind it (`no server running on <path>`) and no socket
+// file at all (`error connecting to <path> (No such file or directory)`).
+// Everything else that makes the probe fail — a timeout, a missing or shadowed
+// tmux binary, EACCES on the socket directory, fork exhaustion, an over-long
+// socket path — is a TRANSPORT fault that says nothing about whether panes are
+// running. Only the two verdicts below may be treated as authoritative absence;
+// conflating them with transport faults would let a single broken tmux
+// invocation tell boot reconciliation that a live fleet is gone.
+const SERVER_ABSENT_RE = /(?:^|\n)(?:no server running on |error connecting to .*\(No such file or directory\))/i;
+
 async function readServerGeneration(port) {
   // Read both fields in one command from one reachable server. Separate tmux
   // clients could straddle a socket replacement and manufacture an identity no
@@ -188,12 +209,20 @@ async function readServerGeneration(port) {
   const result = await tmuxResult([
     'display-message', '-p', `#{${generationOption(port)}}${FIELD_SEP}#{pid}`,
   ], { noStart: true });
-  if (!result.ok) return { reachable: false, generation: null, serverPid: null };
+  if (!result.ok) {
+    return {
+      reachable: false,
+      absent: SERVER_ABSENT_RE.test(String(result.error ?? '')),
+      generation: null,
+      serverPid: null,
+    };
+  }
   const value = result.out.endsWith('\n') ? result.out.slice(0, -1) : result.out;
   const [generation, pidText, ...extra] = value.split(FIELD_SEP);
   const serverPid = Number(pidText);
   return {
     reachable: true,
+    absent: false,
     generation: GENERATION_UUID_RE.test(generation) ? generation.toLowerCase() : null,
     serverPid: extra.length === 0 && Number.isSafeInteger(serverPid) && serverPid > 1 ? serverPid : null,
   };
@@ -213,12 +242,65 @@ function pidState(pid) {
 const sameRecord = (left, right) => !!left && !!right
   && left.generation === right.generation && left.serverPid === right.serverPid;
 
+/** Record the death certificate, then drop the claim. Written FIRST and by
+ * atomic rename: a crash between the two leaves both files, and the claim wins
+ * on the next read (a live claim is always more specific than a certificate for
+ * an older one), so the only cost is a stale certificate that the next
+ * successful claim clears. */
+async function recordRetiredGeneration(home, port, expected) {
+  const file = retiredGenerationFile(home, port);
+  const temp = path.join(home, `.${path.basename(file)}.${process.pid}.${randomUUID()}.tmp`);
+  let handle;
+  try {
+    handle = await open(temp, 'wx', 0o600);
+    await handle.writeFile(`${JSON.stringify({
+      retiredGeneration: expected.generation, retiredServerPid: expected.serverPid,
+    })}\n`, 'utf8');
+    await handle.chmod(0o600);
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await rename(temp, file);
+  } catch (err) {
+    throw new Error(`cannot record retired tmux generation (${err?.code || err?.message || err})`);
+  } finally {
+    try { await handle?.close(); } catch { /* primary error wins */ }
+    try { await unlink(temp); } catch (err) { if (err?.code !== 'ENOENT') { /* best-effort temp cleanup */ } }
+  }
+}
+
+/** Is a proven-dead owner on record for this port? O_NOFOLLOW for the same
+ * reason the claim read uses it. Anything unreadable proves nothing and is
+ * reported as absent-of-proof, which fails closed at the caller. */
+async function hasRetiredGeneration(home, port) {
+  let handle;
+  try {
+    handle = await open(retiredGenerationFile(home, port), fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+  } catch {
+    return false;
+  }
+  try {
+    return (await handle.stat()).isFile();
+  } catch {
+    return false;
+  } finally {
+    try { await handle.close(); } catch { /* proof-read only */ }
+  }
+}
+
+async function clearRetiredGeneration(home, port) {
+  try { await unlink(retiredGenerationFile(home, port)); } catch (err) {
+    if (err?.code !== 'ENOENT') { /* best-effort: a stale certificate only matters while unclaimed */ }
+  }
+}
+
 async function retireDeadGeneration(home, port, expected) {
   if (expected.serverPid === null || pidState(expected.serverPid) !== 'dead') return false;
   // Re-read and re-probe immediately before unlink. A changed record, reused
   // PID, EPERM, or any unknown result leaves the identity untouched.
   const current = await readPersistedGeneration(home, port);
   if (!sameRecord(current, expected) || pidState(expected.serverPid) !== 'dead') return false;
+  await recordRetiredGeneration(home, port, expected);
   try {
     await unlink(generationFile(home, port));
     return true;
@@ -253,19 +335,40 @@ async function prepareServerGenerationUnlocked(home, port) {
     }
     if (expected.serverPid !== null && await retireDeadGeneration(home, port, expected)) {
       // The recorded owner is definitively gone. Resume first-contact: claim a
-      // reachable replacement or let ensureSession create a fresh server. When
-      // no server is reachable, reads may treat the old fleet as authoritatively
-      // empty because the persisted owner PID was proven dead.
+      // reachable replacement, or fall through to the no-claim case below and
+      // let ensureSession create a fresh server.
       expected = null;
       server = await readServerGeneration(port);
-      if (!server.reachable) {
-        return { enabled: true, expected: null, verified: false, authoritativeEmpty: true };
-      }
     } else {
       return { enabled: true, expected, verified: false };
     }
   }
   if (!server.reachable) {
+    // Nothing answering the socket. An empty fleet is a CLAIM ABOUT LIVE PANES,
+    // so it needs proof, and a silent socket is not proof: an unlinked socket is
+    // indistinguishable from no server while the original tmux keeps running
+    // panes behind it. Only two facts together license "authoritatively empty":
+    //
+    //   1. a death certificate — we once claimed a server for this port and
+    //      proved that exact PID gone by ESRCH, which is what proves its panes
+    //      died with it. Absent a certificate (never claimed, or the home was
+    //      wiped) we have no evidence at all and must stay UNKNOWN, because the
+    //      live-server-behind-an-unlinked-socket case looks exactly like this.
+    //   2. server.absent — tmux's own absence verdict rather than a probe that
+    //      merely failed, so a timeout or a shadowed binary cannot impersonate
+    //      an empty fleet and have boot reconciliation tombstone live cards.
+    //
+    // Recording the certificate is what makes this STABLE. The proof used to be
+    // destroyed by the very call that obtained it (retire unlinked the claim),
+    // so exactly one call could answer empty and every later one said UNKNOWN —
+    // and UNKNOWN here cannot heal, because revive, adopt and /rc ask "is this
+    // window free?" BEFORE ensureSession, the only code that ever creates a
+    // server. Refusing them meant no server was created, so the next attempt
+    // refused too: one dead tmux server wedged the board permanently, and the
+    // liveness tick consumed the single recovery seconds after the crash.
+    if (server.absent && await hasRetiredGeneration(home, port)) {
+      return { enabled: true, expected: null, verified: false, authoritativeEmpty: true };
+    }
     return { enabled: true, expected: null, verified: false };
   }
 
@@ -286,6 +389,10 @@ async function prepareServerGenerationUnlocked(home, port) {
     generation: server.generation,
     serverPid: server.serverPid,
   });
+  // A live claim supersedes any death certificate: this port now has a server
+  // again, and the old owner's proof must not outlive it and later license an
+  // "empty" verdict about THIS server's panes.
+  await clearRetiredGeneration(home, port);
   // Re-read after publishing: a socket replacement between set/read/persist is
   // caught here, and a concurrent file claimant's first-writer value wins.
   server = await readServerGeneration(port);
@@ -335,6 +442,27 @@ async function generationVerifiedResult(port, args) {
   return { ok: true, out: result.out.slice(newline + 1), generation: state.expected.generation };
 }
 
+
+/** Can we PROVE that no tmux server is hosting this fleet right now?
+ *
+ * An empty window listing has two very different causes: a healthy server whose
+ * windows were killed, and a server that DIED taking every pane with it. Only
+ * the second is a fleet-wide loss, and only it licenses settling live rows
+ * without probing their panes — a pane cannot outlive the server that ran it.
+ *
+ * True requires the same proof an authoritatively-empty listing does: a death
+ * certificate for the server we claimed (its PID proven gone by ESRCH) AND
+ * tmux's own absence verdict. A reachable server, a failed probe, or no
+ * certificate all return false, so callers never act on a guess — the caller
+ * that condemns rows must never be the one to invent the evidence. */
+export async function fleetServerAbsent(port) {
+  try {
+    const state = await prepareServerGeneration(port);
+    return state.enabled === true && state.authoritativeEmpty === true;
+  } catch {
+    return false; // an unreadable identity proves nothing
+  }
+}
 
 // ------------------------------------------------------------- capability
 let probe = { available: false, reason: `tmux ${MIN_TMUX_VERSION}+ required`, at: 0 };
@@ -389,6 +517,13 @@ function exactTargetPort(target) {
 }
 
 // ----------------------------------------------------------------- session
+/** `has-session` is a PREDICATE: the ok-ness of the result IS the answer. An
+ * authoritatively-empty short circuit reports {ok:true, out:''} for every
+ * command, which is correct for a LISTING (there is nothing to list) and a lie
+ * for a predicate (there is no server, so the session cannot exist). Never let
+ * absence manufacture a session that was never created. */
+const sessionConfirmed = result => result.ok && !result.authoritativeEmpty;
+
 /** Ensure the detached daemon-owned session `fleetdeck-<port>` exists.
  * `=` prefix = exact session-name match (verified; prefix matching could
  * otherwise confuse fleetdeck-4711 with fleetdeck-47110). */
@@ -410,7 +545,7 @@ export async function ensureSession(port) {
       const claimed = await prepareServerGeneration(port);
       if (claimed.verified) {
         const confirmed = await generationVerifiedResult(port, ['has-session', '-t', '=' + name]);
-        if (confirmed.ok) return name;
+        if (sessionConfirmed(confirmed)) return name;
       }
       throw new Error(`tmux server generation could not be claimed for ${name}`);
     }
@@ -419,7 +554,7 @@ export async function ensureSession(port) {
   }
 
   const existing = await generationVerifiedResult(port, ['has-session', '-t', '=' + name]);
-  if (existing.ok) return name;
+  if (sessionConfirmed(existing)) return name;
 
   // -N is present in tmux 3.4+: if the verified server disappears, new-session
   // must fail rather than silently starting a replacement at the same label.
@@ -436,12 +571,12 @@ export async function ensureSession(port) {
   ], { noStart: true });
   if (created.ok && created.out === '') {
     const confirmed = await generationVerifiedResult(port, ['has-session', '-t', '=' + name]);
-    if (confirmed.ok) return name;
+    if (sessionConfirmed(confirmed)) return name;
   }
   // Lost a same-generation session-creation race? Accept only a fresh verified
   // exact-session probe, never an uncorroborated new-session failure.
   const raced = await generationVerifiedResult(port, ['has-session', '-t', '=' + name]);
-  if (raced.ok) return name;
+  if (sessionConfirmed(raced)) return name;
   throw new Error(`tmux could not create session ${name}`);
 }
 

--- a/scripts/fleetd/spawns.mjs
+++ b/scripts/fleetd/spawns.mjs
@@ -1499,6 +1499,60 @@ export function createSpawns(ctx) {
   // single transient dead read (~one tick) while still condemning a genuinely
   // dead pane on the very next tick.
   const CONDEMN_DEAD_READS = 2;
+
+  // ------------------------------------------------------ tmux server watchdog
+  // The liveness tick is the only thing watching tmux, and it watched SILENTLY:
+  // when tmux stopped answering, the board simply froze — every card kept its
+  // last state and nothing said why. Announce the transition ONCE (not every
+  // ~10s tick), after enough consecutive failures to ride out a blip, and
+  // announce the recovery too, so "the board went quiet" is never a mystery.
+  const TMUX_UNREACHABLE_READS = 3;
+  const tmuxWatchdog = { unreachableStreak: 0, announcedUnreachable: false };
+  function noteTmuxUnreachable() {
+    // Two ways of having no tmux are NOT outages and must stay silent, or every
+    // tick turns into a false alarm: the FLEETDECK_SPAWN_CMD override seam runs
+    // without tmux BY CONTRACT (derive.mjs reads a null listing as authoritative
+    // absence there), and a box with no tmux installed never had a server to
+    // lose. Only a tmux that should be answering and isn't is news.
+    if (tmuxAdapter.spawnOverrideCmd?.() || tmuxAdapter.hasTmux?.() === false) return;
+    tmuxWatchdog.unreachableStreak += 1;
+    if (tmuxWatchdog.announcedUnreachable) return;
+    if (tmuxWatchdog.unreachableStreak < TMUX_UNREACHABLE_READS) return;
+    tmuxWatchdog.announcedUnreachable = true;
+    tick('⚠ tmux is not answering — holding every card as-is until it does');
+  }
+
+  /** The fleet's tmux server is PROVEN gone (see tmuxAdapter.fleetServerAbsent).
+   * Settle the rows it took down and stand a fresh server back up, so the board
+   * stops showing panes that no longer exist and the human's ⟲ revive has
+   * somewhere to land. Deliberately does NOT relaunch anyone: resuming an agent
+   * spends money, so that decision stays with the human. */
+  async function mournFleetServer(rows) {
+    tick(`💀 the tmux server died — ${rows.length} spawn(s) went with it; ⟲ revive brings them back`);
+    for (const row of rows) {
+      q.setSpawnStatus.run('gone', row.spawn_id);
+      forgetSpawn(row.spawn_id);
+      const c = q.getSession.get(row.session_id);
+      if (c && c.ended_at == null) {
+        tombstoneCard(row.session_id, {
+          note: `tmux server died — resume with claude --resume ${row.session_id}`,
+        });
+      }
+      logEvent(row.session_id, 'SpawnGone', null, 'tmux server died');
+    }
+    onMutate();
+    // Recovery. Claiming a fresh server also clears the death certificate, so
+    // fleetServerAbsent goes false and this cannot fire twice for one death.
+    try {
+      await tmuxAdapter.ensureSession(port);
+      tick('⟲ tmux server restarted — the fleet is ready to revive');
+    } catch (err) {
+      // Revive still works without a server (it creates one), so this is a
+      // convenience, not a dependency. Say so and let the next tick retry.
+      tick(`⚠ could not restart the tmux server (${String(err?.message || err).slice(0, 80)})`);
+    }
+  }
+
   async function spawnLivenessTick() {
     const rows = q.activeSpawns.all();
     // BUG 3: resurrection candidates count too — if EVERY spawn is already
@@ -1507,7 +1561,26 @@ export function createSpawns(ctx) {
     const resurrectable = q.resurrectableSpawns.all();
     if (!rows.length && !resurrectable.length && !spawnState.orphans.length) return;
     const wins = await tmuxAdapter.listScopedWindows(port);
-    if (wins === null) return; // tmux UNKNOWN: preserve rows, streaks, and orphans
+    if (wins === null) { noteTmuxUnreachable(); return; } // UNKNOWN: preserve rows, streaks, orphans
+    tmuxWatchdog.unreachableStreak = 0;
+    if (tmuxWatchdog.announcedUnreachable) {
+      tmuxWatchdog.announcedUnreachable = false;
+      tick('✓ tmux is answering again');
+    }
+    // TMUX SERVER WATCHDOG. Per-window absence is deliberately UNKNOWN below
+    // ("gone/unreachable at runtime"), which is right for ONE window and wrong
+    // for the whole server: when the tmux server itself dies, every row keeps
+    // its 'live' status forever, the board keeps showing cards that no longer
+    // exist, and Revive answers 409 "spawn is live, not revivable" — the human
+    // is stuck with no way to say "it's dead, bring it back". Ask the one
+    // question that separates a healthy-but-empty server from a dead one, and
+    // act only on proof: a pane cannot outlive the server that ran it, so a
+    // proven-absent server settles its rows without probing panes that are
+    // provably gone. Same evidence boot reconciliation already condemns on.
+    if (!wins.length && rows.length && await tmuxAdapter.fleetServerAbsent?.(port)) {
+      await mournFleetServer(rows);
+      return;
+    }
     for (const row of rows) {
       const win = wins.find(w => w.window === row.tmux_window);
       if (!win) continue; // gone/unreachable at runtime = unknown; boot reconciliation owns 'gone'

--- a/tests/derive-audit-reliability.test.mjs
+++ b/tests/derive-audit-reliability.test.mjs
@@ -229,6 +229,95 @@ test('H-R2: boot reconciliation leaves rows UNKNOWN on list failure without crea
   }
 });
 
+// tmux server watchdog. Per-window absence is UNKNOWN at runtime, which is
+// right for one window and wrong for the whole server: a SIGKILLed tmux left
+// every row 'live' forever, so the board showed panes that no longer existed
+// and revive answered 409 "spawn is live, not revivable" — no way out. The
+// watchdog acts ONLY on proof that the server itself is gone.
+test('tmux watchdog: a proven-dead server settles its fleet, says so, and stands a new server up', async (t) => {
+  const userHome = mkdtempSync(path.join(tmpdir(), 'fd-watchdog-home-'));
+  const cwd = mkdtempSync(path.join(tmpdir(), 'fd-watchdog-cwd-'));
+  t.after(() => {
+    rmSync(userHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    rmSync(cwd, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  let serverAbsent = false;
+  const ensured = [];
+  const tmux = makeAdapter(4711, {
+    fleetServerAbsent: async () => serverAbsent,
+    ensureSession: async p => { ensured.push(p); return `fleetdeck-${p}`; },
+  });
+  const { db, core, state } = memoryCore(t, { tmux, env: { HOME: userHome } });
+
+  const { body } = await core.spawn({ cwd });
+  const { spawn_id: spawnId, session_id: sid } = body;
+  core.hookSessionStart({ session_id: sid, cwd, source: 'startup' });
+  db.prepare("UPDATE spawns SET status='live' WHERE spawn_id=?").run(spawnId);
+  const statusOf = () => db.prepare('SELECT status FROM spawns WHERE spawn_id=?').get(spawnId).status;
+  ensured.length = 0; // spawn() stood the fleet session up; watch only what the tick does
+
+  // A HEALTHY server that simply lists no windows must never condemn: the
+  // window went missing, which is exactly the UNKNOWN the tick already owns.
+  state.windows.length = 0;
+  await core.spawnLivenessTick();
+  assert.equal(statusOf(), 'live', 'an empty listing from a reachable server condemns nothing');
+  assert.deepEqual(ensured, [], 'and never restarts a server that is already there');
+
+  // Now the server itself is provably gone — a pane cannot outlive it.
+  serverAbsent = true;
+  await core.spawnLivenessTick();
+  assert.equal(statusOf(), 'gone', 'the rows it took down are settled, so revive is offered');
+  const died = core.snapshot().ticker.filter(x => /tmux server died/.test(x.msg));
+  assert.equal(died.length, 1, 'the loss is announced exactly once');
+  assert.match(died[0].msg, /1 spawn\(s\) went with it/);
+  assert.deepEqual(ensured, [tmux.port], 'and a fresh fleet session is stood back up');
+
+  // Self-limiting: the fleet is settled, so a second tick re-announces nothing.
+  await core.spawnLivenessTick();
+  assert.equal(
+    core.snapshot().ticker.filter(x => /tmux server died/.test(x.msg)).length,
+    1,
+    'the watchdog does not re-announce a death it already settled',
+  );
+});
+
+test('tmux watchdog: an unreachable tmux is announced once and never condemns anything', async (t) => {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'fd-watchdog-unknown-'));
+  t.after(() => rmSync(cwd, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }));
+  let reachable = true;
+  const tmux = makeAdapter(4711, {
+    listScopedWindows: async () => (reachable ? [] : null),
+    // A failed probe must never be mistaken for proof the server is gone.
+    fleetServerAbsent: async () => false,
+  });
+  const { db, core } = memoryCore(t, { tmux });
+  const { body } = await core.spawn({ cwd });
+  db.prepare("UPDATE spawns SET status='live' WHERE spawn_id=?").run(body.spawn_id);
+
+  reachable = false;
+  const held = () => core.snapshot().ticker.filter(x => /tmux is not answering/.test(x.msg)).length;
+  await core.spawnLivenessTick();
+  assert.equal(held(), 0, 'a single failed read is a blip, not news');
+  await core.spawnLivenessTick();
+  await core.spawnLivenessTick();
+  assert.equal(held(), 1, 'a sustained outage is announced');
+  await core.spawnLivenessTick();
+  assert.equal(held(), 1, 'and announced only once');
+  assert.equal(
+    db.prepare('SELECT status FROM spawns WHERE spawn_id=?').get(body.spawn_id).status,
+    'live',
+    'an unreachable tmux never condemns a row',
+  );
+
+  reachable = true;
+  await core.spawnLivenessTick();
+  assert.ok(
+    core.snapshot().ticker.some(x => /tmux is answering again/.test(x.msg)),
+    'recovery is announced too, so a frozen board is never a mystery',
+  );
+});
+
 test('revive and adopt return 5xx on UNKNOWN window lookup without launching', async (t) => {
   const userHome = mkdtempSync(path.join(tmpdir(), 'fd-unknown-home-'));
   const cwd = mkdtempSync(path.join(tmpdir(), 'fd-unknown-cwd-'));

--- a/tests/tmux-adapter.test.mjs
+++ b/tests/tmux-adapter.test.mjs
@@ -10,6 +10,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { randomBytes, randomInt, randomUUID } from 'node:crypto';
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -182,6 +183,87 @@ exit 1
   assert.equal(readFileSync(creations, 'utf8').trim().split('\n').length, 1, 'expected generation forbids replacement creation');
 });
 
+// Absence is a VERDICT, not a failed probe. Treating every unsuccessful tmux
+// invocation as "the fleet is empty" would let one timed-out or shadowed tmux
+// tell boot reconciliation to tombstone a board full of live panes, so only the
+// two messages tmux itself uses for "nothing is listening here" may be
+// authoritative. Everything else stays UNKNOWN and fails closed.
+test("only tmux's own absence verdict is authoritative; a failed probe stays UNKNOWN", async (t) => {
+  const port = 29_990;
+  const dir = mkdtempSync(path.join(tmpdir(), 'fleetdeck-tmux-absence-'));
+  const fakeTmux = path.join(dir, 'tmux');
+  const previous = new Map([
+    ['PATH', process.env.PATH],
+    ['FLEETDECK_HOME', process.env.FLEETDECK_HOME],
+    ['FLEETDECK_TMUX_SOCKET', process.env.FLEETDECK_TMUX_SOCKET],
+    ['FLEETDECK_FAKE_TMUX_STDERR', process.env.FLEETDECK_FAKE_TMUX_STDERR],
+  ]);
+  // Fails every command, including new-session, with a caller-chosen stderr.
+  writeFileSync(fakeTmux, `#!/bin/sh
+printf '%s\\n' "$FLEETDECK_FAKE_TMUX_STDERR" >&2
+exit 1
+`);
+  chmodSync(fakeTmux, 0o700);
+  process.env.PATH = `${dir}:${process.env.PATH}`;
+  process.env.FLEETDECK_HOME = dir;
+  process.env.FLEETDECK_TMUX_SOCKET = 'adapter-absence-contract';
+  t.after(() => {
+    restoreEnv(previous);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const ABSENCE_VERDICTS = [
+    'no server running on /tmp/tmux-1000/adapter-absence-contract',
+    'error connecting to /tmp/tmux-1000/adapter-absence-contract (No such file or directory)',
+  ];
+  const TRANSPORT_FAULTS = [
+    'connection timed out',
+    'directory /tmp/tmux-1000 has unsafe permissions',
+    'error connecting to /tmp/tmux-1000/x (File name too long)',
+    'lost server',
+    '',
+  ];
+
+  // With no death certificate on record, even tmux's own absence verdict proves
+  // nothing about panes: this is exactly what a live server behind an unlinked
+  // socket looks like.
+  for (const stderr of [...ABSENCE_VERDICTS, ...TRANSPORT_FAULTS]) {
+    process.env.FLEETDECK_FAKE_TMUX_STDERR = stderr;
+    assert.equal(
+      await listScopedWindows(port),
+      null,
+      `unproven absence stays UNKNOWN: ${stderr || '(silent failure)'}`,
+    );
+    // has-session is a predicate: absence must never be read as "it exists".
+    await assert.rejects(
+      ensureSession(port),
+      /generation unavailable|could not create session/,
+      'an unreachable server never fabricates a session that was never created',
+    );
+  }
+  assert.equal(existsSync(path.join(dir, `tmux-generation-${port}`)), false, 'reading claims nothing');
+  assert.equal(existsSync(path.join(dir, `tmux-generation-${port}.retired`)), false, 'and invents no proof');
+
+  // Plant a death certificate: an owner we once claimed, proven gone by ESRCH.
+  writeFileSync(
+    path.join(dir, `tmux-generation-${port}.retired`),
+    `${JSON.stringify({ retiredGeneration: randomUUID(), retiredServerPid: 424242 })}\n`,
+  );
+  for (const verdict of ABSENCE_VERDICTS) {
+    process.env.FLEETDECK_FAKE_TMUX_STDERR = verdict;
+    assert.deepEqual(await listScopedWindows(port), [], `proof + absence verdict is empty: ${verdict}`);
+  }
+  // ...but the certificate never upgrades a probe that merely failed.
+  for (const fault of TRANSPORT_FAULTS) {
+    process.env.FLEETDECK_FAKE_TMUX_STDERR = fault;
+    assert.equal(
+      await listScopedWindows(port),
+      null,
+      `transport fault stays UNKNOWN even with proof: ${fault || '(silent failure)'}`,
+    );
+  }
+});
+
 test('first run creates and claims a tmux server with an owner-only generation file', { skip: !tmuxOk() && 'tmux server unavailable' }, async (t) => {
   const port = 24_000 + randomInt(500);
   const env = isolatedTmuxEnv('fleetdeck-tmux-generation-first-');
@@ -237,6 +319,128 @@ test('ensureSession retires a normally exited tmux owner and claims a new genera
   assert.notEqual(second.serverPid, first.serverPid);
   assert.notEqual(second.generation, first.generation);
   assert.ok(pidAlive(second.serverPid));
+});
+
+// REGRESSION (observed 2026-07-22 on a live fleet): retiring a proven-dead
+// owner used to answer authoritativeEmpty exactly ONCE — from the very call
+// that unlinked the file. Every later lookup saw no claim and no server and
+// answered UNKNOWN, so revive/adopt/rc returned "tmux window lookup failed;
+// revive held to avoid a duplicate session" forever. The liveness tick consumed
+// the single recovery seconds after the crash, long before a human could click
+// Revive, and nothing could heal it because those callers ask their question
+// BEFORE ensureSession — the only code that creates a server. One dead tmux
+// server therefore wedged the whole board permanently. Lookups must stay
+// authoritatively empty for as long as the owner is gone.
+test('a dead tmux owner keeps its old fleet authoritatively empty across repeated lookups', { skip: !tmuxOk() && 'tmux server unavailable' }, async (t) => {
+  const port = 24_900 + randomInt(400);
+  const env = isolatedTmuxEnv('fleetdeck-tmux-generation-wedge-');
+  let newPid = null;
+  t.after(async () => {
+    await stopPid(newPid);
+    restoreEnv(env.previous);
+    rmSync(env.home, { recursive: true, force: true });
+  });
+
+  assert.equal(await ensureSession(port), sessionName(port));
+  const file = path.join(env.home, `tmux-generation-${port}`);
+  const first = JSON.parse(readFileSync(file, 'utf8'));
+
+  tmux(env.socket, ['kill-server']);
+  for (let i = 0; i < 50 && pidAlive(first.serverPid); i += 1) {
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+  assert.equal(pidAlive(first.serverPid), false, 'the persisted owner is definitively dead');
+
+  // The first call retires the dead claim; the ones after it hold no claim at
+  // all. All three answer the same, or a human clicking Revive after the
+  // liveness tick has already run gets a permanent refusal.
+  assert.deepEqual(await listScopedWindows(port), [], 'retiring lookup is authoritatively empty');
+  assert.deepEqual(await listScopedWindows(port), [], 'second lookup is still authoritatively empty');
+  assert.deepEqual(await listScopedWindows(port), [], 'third lookup is still authoritatively empty');
+  assert.equal(existsSync(file), false, 'the dead claim stays retired');
+  assert.equal(existsSync(`${file}.retired`), true, 'the death certificate outlives the claim it replaced');
+  const certificate = JSON.parse(readFileSync(`${file}.retired`, 'utf8'));
+  assert.equal(certificate.retiredServerPid, first.serverPid, 'the certificate names the PID it proved dead');
+  assert.equal(certificate.retiredGeneration, first.generation);
+  assert.equal(statSync(`${file}.retired`).mode & 0o777, 0o600, 'certificate is owner-only');
+
+  // killWindowVerified answers the same question for revive's remnant cleanup:
+  // with the owner gone the window is authoritatively gone, never an error.
+  const killed = await killWindowVerified(`fd${port}-heron`);
+  assert.equal(killed.gone, true, 'a window on a dead owner is gone, not UNKNOWN');
+  assert.equal(killed.error, undefined);
+
+  // And the fleet must still be able to come back up afterwards.
+  assert.equal(await ensureSession(port), sessionName(port));
+  const second = JSON.parse(readFileSync(file, 'utf8'));
+  newPid = second.serverPid;
+  assert.notEqual(second.serverPid, first.serverPid);
+  assert.ok(pidAlive(second.serverPid));
+  assert.equal(
+    existsSync(`${file}.retired`),
+    false,
+    'a live claim supersedes the certificate — the old proof must not outlive this server',
+  );
+  assert.deepEqual(await listScopedWindows(port), [], 'the reclaimed server answers from its own identity');
+});
+
+test('a home that never claimed a server stays UNKNOWN about an absent fleet', async (t) => {
+  // The other side of the coin: absence is only ever licensed by a death
+  // certificate. A home that never claimed a server has no evidence at all, and
+  // "nothing answering the socket" is precisely what a LIVE server whose socket
+  // was unlinked looks like — its panes would still be running. Fail closed.
+  // tests/spawn.test.mjs pins the same contract from the kill side.
+  const port = 25_500 + randomInt(400);
+  const env = isolatedTmuxEnv('fleetdeck-tmux-generation-firstrun-');
+  t.after(() => {
+    restoreEnv(env.previous);
+    rmSync(env.home, { recursive: true, force: true });
+  });
+
+  assert.equal(await listScopedWindows(port), null);
+  assert.equal(
+    existsSync(path.join(env.home, `tmux-generation-${port}`)),
+    false,
+    'reading an absent fleet claims nothing',
+  );
+  assert.equal(
+    existsSync(path.join(env.home, `tmux-generation-${port}.retired`)),
+    false,
+    'and never invents a death certificate it did not earn',
+  );
+});
+
+// The boundary the fix must NOT cross: a claimed server that is still ALIVE but
+// whose socket was unlinked out from under us. Its panes are running and
+// unreachable, so an empty listing is a lie and must stay UNKNOWN — this is the
+// case the whole generation identity exists to catch, and it is distinguished
+// from the retired-owner case above only by the recorded PID still being alive.
+test('an unreachable but still-live claimed server keeps lookups UNKNOWN', { skip: !tmuxOk() && 'tmux server unavailable' }, async (t) => {
+  const port = 25_900 + randomInt(400);
+  const env = isolatedTmuxEnv('fleetdeck-tmux-generation-livesocket-');
+  const fleetWindow = `fd${port}-orca`;
+  let originalPid = null;
+  t.after(async () => {
+    await stopPid(originalPid);
+    restoreEnv(env.previous);
+    rmSync(env.home, { recursive: true, force: true });
+  });
+
+  tmux(env.socket, ['-f', '/dev/null', 'new-session', '-d', '-s', sessionName(port), '-n', fleetWindow, 'sleep 3600']);
+  originalPid = Number(tmux(env.socket, ['display-message', '-p', '#{pid}']));
+  assert.equal((await listScopedWindows(port))?.[0]?.window, fleetWindow, 'the live fleet window is claimed');
+
+  unlinkSync(env.socketPath); // server still running, now unreachable by label
+  assert.equal(await listScopedWindows(port), null, 'a live owner we cannot reach is UNKNOWN, never empty');
+  assert.equal(
+    existsSync(path.join(env.home, `tmux-generation-${port}`)),
+    true,
+    'a claim whose PID is alive is never retired',
+  );
+  const killed = await killWindowVerified(fleetWindow);
+  assert.equal(killed.gone, undefined, 'an unreachable live window is never authoritatively gone');
+  assert.match(killed.error, /generation/i);
+  assert.ok(pidAlive(originalPid), 'the original server and its panes are left alone');
 });
 
 test('an unlinked socket replacement cannot impersonate the claimed tmux server', { skip: !tmuxOk() && 'tmux server unavailable' }, async (t) => {


### PR DESCRIPTION
Losing the tmux server took the whole board with it — silently, and then permanently. Every spawn vanished at once with nothing said about why, and from then on ⟲ revive answered `503 tmux window lookup failed; revive held to avoid a duplicate session` forever, with no way back except starting a tmux server by hand. Found on a live fleet today.

### Added

- **A tmux server watchdog.** The liveness tick was the only thing watching tmux and it watched in silence. Per-window absence is deliberately UNKNOWN at runtime — right for one window, wrong for the whole server — which meant a SIGKILLed tmux left every row `live` forever: the board kept showing panes that no longer existed and revive answered `409 spawn is live, not revivable`, with no way for a human to say "it's dead, bring it back". The tick now asks the one question that separates a healthy-but-empty server from a dead one, and acts only on proof:
  - the loss is announced once — `💀 the tmux server died — N spawn(s) went with it`;
  - the rows it took down are settled to `gone`, so Revive is offered instead of a 409;
  - a fresh fleet session is stood back up.

  It never relaunches an agent: that spends money and stays a human decision. A tmux that merely stops answering is reported once (with a matching recovery line) and condemns nothing.

### Fixed

- **Revive no longer wedges permanently when the tmux server dies.** Proving the recorded owner dead (ESRCH) is what proves its panes died with it — and retiring the claim *destroyed that proof at the instant it was obtained*, so exactly one call could answer "empty" and every call after it went back to UNKNOWN. UNKNOWN cannot heal here, because revive/adopt/`/rc` ask "is this window free?" *before* `ensureSession`, the only code that ever creates a server. The proof is now kept as a death certificate that outlives the claim and is cleared by the next successful claim. A home that never claimed a server still reports UNKNOWN — with no certificate there is no evidence, and a silent socket is exactly what a live server behind an unlinked socket looks like (the contract `tests/spawn.test.mjs` already pins from the kill side).
- **A failed tmux probe is no longer mistaken for an empty fleet.** Only tmux's own two absence verdicts count as proof; a timeout, a shadowed binary or an unreadable socket dir stays UNKNOWN and fails closed. Previously any of them could have told boot reconciliation that a board full of live panes was gone.
- **`ensureSession` can no longer report success without a tmux server.** `has-session` is a predicate, so an authoritatively-empty short circuit must not be read as "the session exists".

### Verification

Real-tmux lifecycle, end to end:

```
1. nothing ever claimed          absent=false list=null   ← fail-closed, as designed
2. server up, one fleet window   absent=false list=[fd4711-heron]
3. server dead → watchdog fires  absent=true  list=[]
4. again (used to wedge here)    absent=true  list=[]     ← stable now, was null
5. after watchdog recovery       absent=false list=[]
```

7 new tests across `tests/tmux-adapter.test.mjs` and `tests/derive-audit-reliability.test.mjs`; each fails against the code without its fix and passes with it, and the guard tests (never-claimed stays UNKNOWN, live-but-unreachable stays UNKNOWN) pass either way. Bundle regenerated for the drift gate.

Note: `R1-2: a /ws client past the buffer cap` is a pre-existing load-sensitive flake — it fails on clean `main` under full-suite load and passes 3/3 in isolation. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)