### PR TITLE
v0.22.1 — postcss build-chain security patch (closes dependabot alert #1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "source": "./",
       "displayName": "Fleet Deck",
       "description": "Localhost fleet board for Claude Code: every session on the machine visible on one board, cross-session file-conflict whispers, and turn-boundary mail between sessions. Zero wrapper, zero model calls in the core. Tested against Claude Code 2.1.206+ (through 2.1.207).",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "author": {
         "name": "Luis Morales"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck",
   "displayName": "Fleet Deck",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Localhost fleet board for Claude Code: every session on the machine visible on one board, cross-session file-conflict whispers, and turn-boundary mail between sessions. Zero wrapper, zero model calls in the core. Tested against Claude Code 2.1.206+ (through 2.1.207).",
   "author": {
     "name": "Luis Morales",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Fleet Deck are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.1] - 2026-08-06
+
+A build-chain security patch, out the same day. Dependabot's alert, our
+release gates: postcss (transitive build tooling under the board's
+Vite/Tailwind pipeline) allowed an attacker-controlled `sourceMappingURL` to
+read arbitrary `.map` files when `from` is unset — the incomplete fix of
+GHSA-6g55-p6wh-862q, patched upstream in 8.5.23.
+
+### Security
+
+- **postcss 8.5.19 → 8.5.26 in `/board`** (with nanoid 3.3.16 → 3.3.17 as its
+  dependency floor). The rebuilt board bundle is byte-identical — the
+  vulnerable code path lives in the build chain, not in anything Fleet Deck
+  ships — but the lockfile is part of the plugin's release-bound payload
+  closure, so the fix rides a release rather than drifting in silently.
+
 ## [0.22.0] - 2026-08-06
 
 The bug bash. A line-by-line audit of Fleet Deck — the daemon, the board, the

--- a/board/package-lock.json
+++ b/board/package-lock.json
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -758,9 +758,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -778,7 +778,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/board/package-lock.json
+++ b/board/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetdeck-board",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetdeck-board",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",

--- a/board/package.json
+++ b/board/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck-board",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.22.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetdeck",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetdeck",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetdeck",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Fleet Deck — localhost daemon + board that makes every Claude Code session on a machine visible. Tested against Claude Code 2.1.206.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## v0.22.1 — postcss build-chain security patch

Supersedes dependabot PR #21 and closes **dependabot security alert #1** (medium): postcss ≤ 8.5.22 lets an attacker-controlled `sourceMappingURL` read arbitrary `.map` files when `from` is unset (incomplete fix of GHSA-6g55-p6wh-862q, patched upstream in 8.5.23). This bumps the `/board` lockfile to **postcss 8.5.26** (+ nanoid 3.3.17 as its dependency floor).

**Why this is a release, not just a lockfile bump:** the rebuilt `board-dist` is byte-identical — the vulnerable path lives in the build chain, not in anything Fleet Deck ships — but `board/package-lock.json` is part of the plugin's release-bound payload closure (the BUG-001 gate), so the change must ride a version. All nine version strings agree on **0.22.1**; bundle and board-dist drift gates are clean; the payload and release gates pass against `main`.

Dependabot's own PR (#21) can't perform the version bump the gate demands, and will auto-close once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
