### PR TITLE
v0.22.3 — the run nonce must identify the CLI process, not the hook invocation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "source": "./",
       "displayName": "Fleet Deck",
       "description": "Localhost fleet board for Claude Code: every session on the machine visible on one board, cross-session file-conflict whispers, and turn-boundary mail between sessions. Zero wrapper, zero model calls in the core. Tested against Claude Code 2.1.206+ (through 2.1.207).",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "author": {
         "name": "Luis Morales"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck",
   "displayName": "Fleet Deck",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Localhost fleet board for Claude Code: every session on the machine visible on one board, cross-session file-conflict whispers, and turn-boundary mail between sessions. Zero wrapper, zero model calls in the core. Tested against Claude Code 2.1.206+ (through 2.1.207).",
   "author": {
     "name": "Luis Morales",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to Fleet Deck are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.3] - 2026-08-07
+
+The board could not tell one CLI run from another, so it discarded every
+session's exit.
+
+### Fixed
+
+- **Exiting the CLI did nothing: no tombstone, and move-to-tmux never fired.**
+  The run nonce that lets the daemon tell a delayed `SessionEnd` (from a dead
+  process) apart from a live `claude --resume` was keyed on the hook shim's
+  parent pid. Claude Code runs each hook through a fresh intermediate shell, so
+  that key changed on *every hook*: `SessionStart` recorded nonce A, the
+  `SessionEnd` that followed minted B, and B ≠ A made every tagged end look
+  like it came from a previous run. Measured on one real session before the
+  fix: **510 nonce files, 510 distinct values, none matching the card's run.**
+
+  Two visible consequences. A hook-only session never tombstoned when you
+  exited — its card stayed live until the silence sweep hours later. And an
+  armed **move to tmux** could never happen: the arm is consumed further down
+  the very function the guard returns from, so the card stayed armed and
+  nothing moved, with no error anywhere.
+
+  The nonce is now keyed on the CLI process itself (`CLAUDE_PID`, with a
+  `/proc` ancestor walk and then the old ppid as fallbacks), so every hook of
+  one run agrees and a `--resume` still gets a fresh nonce — which is what the
+  original guard needs to keep working. Both shims now share one module rather
+  than each carrying their own copy of the logic.
+- **Nonce files are now collected.** Nothing ever removed them; a long-lived
+  home accumulated one per session forever (and, before this fix, one per
+  hook). The retention sweep now drops a file only when its pid is provably
+  dead and the file has aged, so a live CLI never loses the nonce its next hook
+  will read.
+
 ## [0.22.2] - 2026-08-07
 
 Dependency maintenance only — no behaviour change.

--- a/board/package-lock.json
+++ b/board/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetdeck-board",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetdeck-board",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",

--- a/board/package.json
+++ b/board/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck-board",
   "private": true,
-  "version": "0.22.2",
+  "version": "0.22.3",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetdeck",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetdeck",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetdeck",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Fleet Deck — localhost daemon + board that makes every Claude Code session on a machine visible. Tested against Claude Code 2.1.206.",
   "type": "module",
   "license": "MIT",

--- a/scripts/fleet-hook.mjs
+++ b/scripts/fleet-hook.mjs
@@ -24,38 +24,22 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { randomUUID } from 'node:crypto';
 import { resolveHome, resolvePort, resolveBase } from './fleetd/config.mjs';
+import { runNonce } from './fleetd/run-nonce.mjs';
 
 const EVENT = process.argv[2];
 const HOME = resolveHome();
 const BASE = resolveBase(resolvePort());
 
-// Run generation (BUG-025): ONE nonce per CLI process, minted by whichever
-// shim runs first (the SessionStart hook, or this one when a mid-session event
-// is the process's first) and shared via a dotfile in FLEETDECK_HOME —
-// hooks spawn a fresh shim process per event, so the file is the handoff.
-// SessionStart persists it as the card's active run; the daemon then refuses
-// to tombstone on a SessionEnd from any OTHER (older, delayed-async) run of
-// the same session id. Mint-and-attach only when the payload carries none —
-// never overwrite a nonce a newer daemon-side flow already set. Any failure
-// leaves the event untagged, which the daemon treats as the historical
-// unconditional-tombstone path (fail open, never break the session).
-let RUN = null;
-try {
-  const runFile = path.join(HOME, `run-${process.ppid}`);
-  try {
-    RUN = fs.readFileSync(runFile, 'utf8').trim() || null;
-  } catch {
-    RUN = randomUUID();
-    // 0600 like the rest of HOME's state (token, log, db). A stale file from a
-    // crashed CLI could be re-read by an unrelated later process only if the
-    // pid was recycled AND the event carries the same session_id — worst case
-    // that session's own SessionEnd is then skipped, failing safe toward a
-    // live card the retention sweep later settles.
-    fs.writeFileSync(runFile, RUN, { mode: 0o600 });
-  }
-} catch { RUN = null; }
+// Run generation (BUG-025): ONE nonce per CLI PROCESS, shared by every hook
+// that process fires, so the daemon can tell a delayed SessionEnd from a dead
+// run apart from the live one. Keyed on the CLI itself (CLAUDE_PID) — NOT on
+// this shim's parent, which is a fresh shell per hook and therefore minted a
+// new nonce every single time, making every tagged SessionEnd look stale.
+// Mint-and-attach only when the payload carries none; any failure leaves the
+// event untagged, which the daemon treats as the historical
+// unconditional-tombstone path. See run-nonce.mjs for the measured failure.
+const RUN = runNonce(HOME);
 
 function withRun(raw) {
   if (!RUN) return raw;

--- a/scripts/fleet-sessionstart.mjs
+++ b/scripts/fleet-sessionstart.mjs
@@ -22,9 +22,9 @@
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { CLAUDE_ENV_MARKERS, GATEWAY_ENV_VARS, SPAWN_ENV_VARS } from './fleetd/env-scrub.mjs';
+import { runNonce } from './fleetd/run-nonce.mjs';
 // Version-takeover contract, imported as SOURCE from the sibling fleetd/ dir
 // (same unbundled pattern as env-scrub.mjs above) so this hook can evict a
 // strictly-older daemon and let the newest installed build own the port.
@@ -281,15 +281,12 @@ try {
   // payload untagged (the daemon's historical behavior) — never break the
   // session.
   try {
+    // Keyed on the CLI process (CLAUDE_PID), not this shim's parent — see
+    // run-nonce.mjs. A ppid key gave every hook its own nonce, so the run this
+    // registers could never be matched by the SessionEnd that followed.
     if (payload.fleet_run == null) {
-      const runFile = path.join(HOME, `run-${process.ppid}`);
-      let run = null;
-      try { run = fs.readFileSync(runFile, 'utf8').trim() || null; } catch { /* first hook of this process */ }
-      if (!run) {
-        run = randomUUID();
-        fs.writeFileSync(runFile, run, { mode: 0o600 });
-      }
-      payload.fleet_run = run;
+      const run = runNonce(HOME);
+      if (run) payload.fleet_run = run;
     }
   } catch { /* untagged registration still registers */ }
   const serverUp = await ensureServer();

--- a/scripts/fleetd/fleetd.bundle.mjs
+++ b/scripts/fleetd/fleetd.bundle.mjs
@@ -3712,10 +3712,10 @@ var require_websocket_server = __commonJS({
 });
 
 // scripts/fleetd/fleetd.mjs
-import fs16 from "node:fs";
+import fs17 from "node:fs";
 import crypto2 from "node:crypto";
 import os9 from "node:os";
-import path17 from "node:path";
+import path18 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // scripts/fleetd/db.mjs
@@ -4070,8 +4070,8 @@ function openDb(file, fsImpl = { chmodSync, statSync }) {
 }
 
 // scripts/fleetd/derive.mjs
-import fs13 from "node:fs";
-import path14 from "node:path";
+import fs14 from "node:fs";
+import path15 from "node:path";
 
 // scripts/fleetd/repo-identity.mjs
 import { execFileSync } from "node:child_process";
@@ -12069,7 +12069,44 @@ function createSnapshot(ctx) {
 }
 
 // scripts/fleetd/retention.mjs
+import fs13 from "node:fs";
+
+// scripts/fleetd/run-nonce.mjs
 import fs12 from "node:fs";
+import path14 from "node:path";
+var isPid = (v) => Number.isInteger(v) && v > 0;
+function pruneRunNonces(home, { minAgeMs = 36e5, now = Date.now() } = {}) {
+  if (!home) return 0;
+  let removed = 0;
+  let names;
+  try {
+    names = fs12.readdirSync(home);
+  } catch {
+    return 0;
+  }
+  for (const name of names) {
+    const m = /^run-(\d+)$/.exec(name);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    if (!isPid(pid)) continue;
+    const file = path14.join(home, name);
+    try {
+      if (now - fs12.statSync(file).mtimeMs < minAgeMs) continue;
+      try {
+        process.kill(pid, 0);
+        continue;
+      } catch (err) {
+        if (err?.code !== "ESRCH") continue;
+      }
+      fs12.unlinkSync(file);
+      removed += 1;
+    } catch {
+    }
+  }
+  return removed;
+}
+
+// scripts/fleetd/retention.mjs
 function createRetention(ctx) {
   const {
     q,
@@ -12080,6 +12117,7 @@ function createRetention(ctx) {
     forgetSpawn,
     tmuxAdapter,
     port,
+    home,
     questions,
     adoptSession,
     scopedPaneTarget,
@@ -12187,6 +12225,7 @@ function createRetention(ctx) {
     if (q.goneArchivedSpawns.run().changes) changed = true;
     const touchCutoff = now - Math.max(RETAIN_LEDGER_MS, CONFLICT_WINDOW_MS);
     if (q.pruneTouches.run(touchCutoff).changes) changed = true;
+    pruneRunNonces(home, { now });
     const ledgerCutoff = now - RETAIN_LEDGER_MS;
     if (q.pruneCommands.run(ledgerCutoff).changes) changed = true;
     if (q.pruneConflicts.run(ledgerCutoff).changes) changed = true;
@@ -12262,7 +12301,7 @@ function createRetention(ctx) {
     const feed_cleared = Number(q.clearTicker.run().changes);
     const orphan_worktrees = q.orphanWorktrees.all().map((r) => r.worktree_path).filter((p) => {
       try {
-        return fs12.existsSync(p);
+        return fs13.existsSync(p);
       } catch {
         return false;
       }
@@ -12507,7 +12546,7 @@ function createCore(db2, {
   function stampTranscriptFloor(sid, transcriptPath) {
     let floor = 0;
     try {
-      if (transcriptPath) floor = fs13.statSync(transcriptPath).size;
+      if (transcriptPath) floor = fs14.statSync(transcriptPath).size;
     } catch {
     }
     modelMemo.set(sid, { floor, size: -1, model: null });
@@ -12516,7 +12555,7 @@ function createCore(db2, {
     const memo = modelMemo.get(sid) ?? { floor: 0, size: -1, model: null };
     let size;
     try {
-      size = fs13.statSync(transcriptPath).size;
+      size = fs14.statSync(transcriptPath).size;
     } catch {
       return null;
     }
@@ -12824,9 +12863,9 @@ function createCore(db2, {
   const custodyLeases = /* @__PURE__ */ new Map();
   const canonicalWorktreePath = (p) => {
     try {
-      return fs13.realpathSync(p);
+      return fs14.realpathSync(p);
     } catch {
-      return path14.resolve(p);
+      return path15.resolve(p);
     }
   };
   ctx.claimWorktreeCustody = (p, owner) => {
@@ -13000,8 +13039,8 @@ function createCore(db2, {
 import http from "node:http";
 import { timingSafeEqual } from "node:crypto";
 import os8 from "node:os";
-import fs14 from "node:fs";
-import path15 from "node:path";
+import fs15 from "node:fs";
+import path16 from "node:path";
 import { fileURLToPath } from "node:url";
 
 // node_modules/ws/wrapper.mjs
@@ -13496,7 +13535,7 @@ function isLoopbackAddress(address) {
   const value = String(address || "").trim().toLowerCase();
   return value === "localhost" || value === "::1" || /^127(?:\.[0-9]{1,3}){3}$/.test(value) || /^::ffff:127(?:\.[0-9]{1,3}){3}$/.test(value);
 }
-var BOARD_DIST = path15.join(path15.dirname(fileURLToPath(import.meta.url)), "board-dist");
+var BOARD_DIST = path16.join(path16.dirname(fileURLToPath(import.meta.url)), "board-dist");
 var MIME = {
   ".html": "text/html; charset=utf-8",
   ".js": "text/javascript; charset=utf-8",
@@ -13520,15 +13559,15 @@ function serveBoardAsset(res, pathname, notFound) {
     return notFound();
   }
   const rel = decoded === "/" ? "index.html" : decoded.replace(/^\/+/, "");
-  const abs = path15.resolve(BOARD_DIST, rel);
-  if (abs !== BOARD_DIST && !abs.startsWith(BOARD_DIST + path15.sep)) return notFound();
+  const abs = path16.resolve(BOARD_DIST, rel);
+  if (abs !== BOARD_DIST && !abs.startsWith(BOARD_DIST + path16.sep)) return notFound();
   let data;
   try {
-    data = fs14.readFileSync(abs);
+    data = fs15.readFileSync(abs);
   } catch {
     return notFound();
   }
-  const ext = path15.extname(abs).toLowerCase();
+  const ext = path16.extname(abs).toLowerCase();
   const headers = {
     "content-type": MIME[ext] || "application/octet-stream",
     "content-length": data.length,
@@ -15226,8 +15265,8 @@ function createMdns({ port, name = "fleetdeck", instance = "Fleet Deck", address
 }
 
 // scripts/fleetd/takeover.mjs
-import fs15 from "node:fs";
-import path16 from "node:path";
+import fs16 from "node:fs";
+import path17 from "node:path";
 function pidRecord(text) {
   try {
     const parsed = JSON.parse(String(text));
@@ -15250,8 +15289,8 @@ function pidIsLive(pid) {
 function livePidLooksLikeFleetd(pid) {
   if (process.platform !== "linux") return true;
   try {
-    const executable = path16.basename(fs15.readlinkSync(`/proc/${pid}/exe`)).replace(/ \(deleted\)$/, "");
-    const argv = fs15.readFileSync(`/proc/${pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
+    const executable = path17.basename(fs16.readlinkSync(`/proc/${pid}/exe`)).replace(/ \(deleted\)$/, "");
+    const argv = fs16.readFileSync(`/proc/${pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
     const nodeLike = /^(?:node|nodejs|fleetd)$/i.test(executable);
     const fleetdScript = argv.some((arg) => /(?:^|[/\\])fleetd(?:\.bundle)?\.mjs$/.test(arg));
     return nodeLike && fleetdScript;
@@ -15319,7 +15358,7 @@ function verifyDaemonPid(pid, home) {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   let record = null;
   try {
-    record = pidRecord(fs15.readFileSync(path16.join(home, "fleetd.pid"), "utf8"));
+    record = pidRecord(fs16.readFileSync(path17.join(home, "fleetd.pid"), "utf8"));
   } catch {
     return false;
   }
@@ -15344,13 +15383,13 @@ async function terminateDaemon(pid, { timeoutMs = 2e3, sleep = defaultSleep } = 
 }
 
 // scripts/fleetd/fleetd.mjs
-var __dirname = path17.dirname(fileURLToPath2(import.meta.url));
+var __dirname = path18.dirname(fileURLToPath2(import.meta.url));
 var PORT;
 try {
   PORT = resolvePort();
 } catch (err) {
   try {
-    fs16.writeSync(2, `fleetd refused to start: ${err.message}
+    fs17.writeSync(2, `fleetd refused to start: ${err.message}
 `);
   } catch {
   }
@@ -15358,7 +15397,7 @@ try {
 }
 if (!Number.isInteger(PORT) || PORT < 0 || PORT > 65535) {
   try {
-    fs16.writeSync(2, `fleetd refused to start: FLEETDECK_PORT must be an integer between 0 and 65535 (got '${process.env.FLEETDECK_PORT}')
+    fs17.writeSync(2, `fleetd refused to start: FLEETDECK_PORT must be an integer between 0 and 65535 (got '${process.env.FLEETDECK_PORT}')
 `);
   } catch {
   }
@@ -15378,22 +15417,22 @@ function startupFatal(reason) {
   } catch {
   }
   try {
-    fs16.writeSync(2, `fleetd refused to start: ${reason}
+    fs17.writeSync(2, `fleetd refused to start: ${reason}
 `);
   } catch {
   }
   process.exit(1);
 }
 try {
-  fs16.mkdirSync(HOME, { recursive: true });
+  fs17.mkdirSync(HOME, { recursive: true });
 } catch (err) {
   startupFatal(`cannot create FLEETDECK_HOME (${err?.code || err?.message || "unknown error"})`);
 }
 try {
-  fs16.chmodSync(HOME, 448);
+  fs17.chmodSync(HOME, 448);
 } catch {
 }
-var PID_FILE = path17.join(HOME, "fleetd.pid");
+var PID_FILE = path18.join(HOME, "fleetd.pid");
 var ownsPidFile = false;
 var version = "0.0.0";
 var versionOverride = process.env.FLEETDECK_VERSION_OVERRIDE?.trim();
@@ -15401,15 +15440,15 @@ if (versionOverride) {
   version = versionOverride;
 } else {
   try {
-    version = JSON.parse(fs16.readFileSync(path17.resolve(__dirname, "../../package.json"), "utf8")).version || version;
+    version = JSON.parse(fs17.readFileSync(path18.resolve(__dirname, "../../package.json"), "utf8")).version || version;
   } catch {
   }
 }
 function removeOwnedPidFile() {
   if (!ownsPidFile) return;
   try {
-    const record = pidRecord(fs16.readFileSync(PID_FILE, "utf8"));
-    if (record?.pid === process.pid) fs16.unlinkSync(PID_FILE);
+    const record = pidRecord(fs17.readFileSync(PID_FILE, "utf8"));
+    if (record?.pid === process.pid) fs17.unlinkSync(PID_FILE);
   } catch {
   }
   ownsPidFile = false;
@@ -15435,7 +15474,7 @@ async function supersedeIfNewer(record) {
 async function claimHome() {
   for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
-      fs16.writeFileSync(PID_FILE, JSON.stringify({ pid: process.pid, port: PORT }), {
+      fs17.writeFileSync(PID_FILE, JSON.stringify({ pid: process.pid, port: PORT }), {
         encoding: "utf8",
         mode: 384,
         flag: "wx"
@@ -15450,7 +15489,7 @@ async function claimHome() {
     let recordText = null;
     let record = null;
     try {
-      recordText = fs16.readFileSync(PID_FILE, "utf8");
+      recordText = fs17.readFileSync(PID_FILE, "utf8");
       record = pidRecord(recordText);
     } catch (err) {
       if (err?.code === "ENOENT") continue;
@@ -15462,13 +15501,13 @@ async function claimHome() {
       startupFatal(`FLEETDECK_HOME is already used by live fleetd pid ${record.pid} on ${port}; use a separate FLEETDECK_HOME for another daemon (if that PID was recycled, remove stale pidfile ${PID_FILE})`);
     }
     try {
-      if (fs16.readFileSync(PID_FILE, "utf8") !== recordText) continue;
+      if (fs17.readFileSync(PID_FILE, "utf8") !== recordText) continue;
     } catch (err) {
       if (err?.code === "ENOENT") continue;
       startupFatal(`cannot re-read stale FLEETDECK_HOME pidfile (${err?.code || err?.message || "unknown error"})`);
     }
     try {
-      fs16.unlinkSync(PID_FILE);
+      fs17.unlinkSync(PID_FILE);
     } catch (err) {
       if (err?.code !== "ENOENT") startupFatal(`cannot clear stale FLEETDECK_HOME pidfile (${err?.code || err?.message || "unknown error"})`);
     }
@@ -15502,7 +15541,7 @@ if (TRUST_LOOPBACK && LAN_MODE) {
   startupFatal("FLEETDECK_TRUST_LOOPBACK=on requires a loopback FLEETDECK_BIND");
 }
 var TOKEN_REQUIRED = LAN_MODE || REQUIRE_TOKEN || TRUSTED_ORIGINS.length > 0 && PROXY_AUTH === "token";
-var TOKEN_FILE = path17.join(HOME, "token");
+var TOKEN_FILE = path18.join(HOME, "token");
 var TOKEN;
 if (Object.hasOwn(process.env, "FLEETDECK_TOKEN")) {
   TOKEN = String(process.env.FLEETDECK_TOKEN).trim();
@@ -15512,7 +15551,7 @@ if (Object.hasOwn(process.env, "FLEETDECK_TOKEN")) {
   }
 } else {
   try {
-    const persisted = fs16.readFileSync(TOKEN_FILE, "utf8").trim();
+    const persisted = fs17.readFileSync(TOKEN_FILE, "utf8").trim();
     if (persisted.length >= 16) TOKEN = persisted;
     else if (TOKEN_REQUIRED) startupFatal("FLEETDECK_HOME/token must contain at least 16 characters");
   } catch (err) {
@@ -15528,7 +15567,7 @@ if (!TOKEN) {
     startupFatal(`cannot generate access token (${err?.code || err?.message || "unknown error"})`);
   }
   try {
-    fs16.writeFileSync(TOKEN_FILE, TOKEN, { encoding: "utf8", mode: 384, flag: "wx" });
+    fs17.writeFileSync(TOKEN_FILE, TOKEN, { encoding: "utf8", mode: 384, flag: "wx" });
   } catch (err) {
     if (TOKEN_REQUIRED) {
       startupFatal(`cannot persist FLEETDECK_HOME/token (${err?.code || err?.message || "unknown error"})`);
@@ -15539,7 +15578,7 @@ if (!TOKEN) {
 if (TOKEN) {
   let onDisk = null;
   try {
-    onDisk = fs16.readFileSync(TOKEN_FILE, "utf8");
+    onDisk = fs17.readFileSync(TOKEN_FILE, "utf8");
   } catch (err) {
     if (err?.code !== "ENOENT") {
       startupFatal(`cannot read FLEETDECK_HOME/token (${err?.code || err?.message || "unknown error"})`);
@@ -15547,7 +15586,7 @@ if (TOKEN) {
   }
   if (onDisk === null || onDisk.trim() !== TOKEN) {
     try {
-      fs16.writeFileSync(TOKEN_FILE, TOKEN, { encoding: "utf8", mode: 384 });
+      fs17.writeFileSync(TOKEN_FILE, TOKEN, { encoding: "utf8", mode: 384 });
     } catch (err) {
       if (TOKEN_REQUIRED) {
         startupFatal(`cannot persist FLEETDECK_HOME/token (${err?.code || err?.message || "unknown error"})`);
@@ -15557,7 +15596,7 @@ if (TOKEN) {
   }
   if (onDisk !== null) {
     try {
-      fs16.chmodSync(TOKEN_FILE, 384);
+      fs17.chmodSync(TOKEN_FILE, 384);
     } catch (err) {
       const why = err?.code || err?.message || "unknown error";
       if (TOKEN_REQUIRED) {
@@ -15575,7 +15614,7 @@ function mdnsInstanceName() {
     return "Fleet Deck";
   }
 }
-var DB_FILE = path17.join(HOME, "fleetd.db");
+var DB_FILE = path18.join(HOME, "fleetd.db");
 var db = openDb(DB_FILE);
 var core = createCore(db, { port: PORT, version });
 var settleReconciliation;

--- a/scripts/fleetd/retention.mjs
+++ b/scripts/fleetd/retention.mjs
@@ -10,11 +10,12 @@
 import fs from 'node:fs';
 import { SHELL_RE, NOT_RESUMABLE_END } from './helpers.mjs';
 import { CONFLICT_WINDOW_MS } from './ledger.mjs';
+import { pruneRunNonces } from './run-nonce.mjs';
 
 export function createRetention(ctx) {
   const {
     q, updateSession, tick, onMutate, tombstoneCard, forgetSpawn,
-    tmuxAdapter, port, questions, adoptSession, scopedPaneTarget,
+    tmuxAdapter, port, home, questions, adoptSession, scopedPaneTarget,
     PRESUME_DEAD_MS, PRESUME_DEAD_WORKING_MS, RETAIN_OFFLINE_MS, RETAIN_LEDGER_MS,
   } = ctx;
 
@@ -200,6 +201,12 @@ export function createRetention(ctx) {
     // consider (BUG-144). Commands/conflicts/mail keep the configured horizon.
     const touchCutoff = now - Math.max(RETAIN_LEDGER_MS, CONFLICT_WINDOW_MS);
     if (q.pruneTouches.run(touchCutoff).changes) changed = true;
+    // Hook run-nonce files (one per CLI process, HOME/run-<pid>) are the only
+    // state here nothing ever collected: one per session for the life of the
+    // HOME. Removed only when the pid is provably dead and the file has aged,
+    // so a live CLI never loses the nonce its next hook will read. (Before the
+    // keying fix these accumulated per HOOK — 510 in one observed session.)
+    pruneRunNonces(home, { now });
     const ledgerCutoff = now - RETAIN_LEDGER_MS;
     if (q.pruneCommands.run(ledgerCutoff).changes) changed = true;
     if (q.pruneConflicts.run(ledgerCutoff).changes) changed = true;

--- a/scripts/fleetd/run-nonce.mjs
+++ b/scripts/fleetd/run-nonce.mjs
@@ -1,0 +1,133 @@
+// run-nonce.mjs — ONE run nonce per CLI PROCESS, shared by every hook that
+// process fires.
+//
+// WHY THIS EXISTS. SessionEnd is an async hook while SessionStart is
+// synchronous, so a `claude --resume` (a NEW process reusing the SAME session
+// id) can register and go live BEFORE the previous process's SessionEnd lands.
+// The daemon refuses to tombstone on a SessionEnd whose nonce is not the card's
+// active run, which is what stops a delayed end from killing a live resumed
+// session. That guard is only as good as the nonce's identity.
+//
+// THE BUG THIS FIXES. The nonce used to be keyed on `process.ppid`, on the
+// assumption that the hook's parent IS the CLI. It is not: Claude Code runs
+// each hook through a fresh intermediate shell, so every hook invocation sees a
+// DIFFERENT parent pid, minted a brand-new nonce, and wrote another
+// `run-<pid>` file. Measured on one real session: 510 nonce files, 510 distinct
+// values, none of them equal to the card's recorded run.
+//
+// The consequence was systematic rather than occasional. SessionStart stored
+// nonce A; the SessionEnd that followed minted B; B !== A, so EVERY tagged
+// SessionEnd looked like it came from a dead previous run and was discarded.
+// Hook-only sessions therefore never tombstoned on exit (they lingered until
+// the silence sweep hours later), an armed move-to-tmux could never fire (the
+// arm is consumed further down the same function the guard returns from), and
+// HOME accumulated one stray file per hook.
+//
+// THE KEY. Claude Code exports CLAUDE_PID — the pid of the CLI process itself
+// — and it is visible to hooks through any intervening shell. That is exactly
+// the identity the nonce is supposed to track: stable for every hook of one CLI
+// process, and DIFFERENT for a `--resume`, which is a new process and must get
+// a new nonce or the guard above stops working.
+//
+// Fallback order, most to least trustworthy:
+//   1. CLAUDE_PID           — the CLI's own pid, what we want
+//   2. the nearest `claude` ancestor via /proc (Linux)  — same answer, derived
+//   3. process.ppid         — the historical behaviour; wrong when a shell sits
+//                             in between, but never worse than before
+//
+// Every failure path returns null, which leaves the event UNTAGGED — the
+// daemon's historical unconditional-tombstone path. Fail open; never break the
+// session.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+const isPid = v => Number.isInteger(v) && v > 0;
+
+/** The nearest ancestor that is the Claude CLI, read from /proc (Linux only). */
+function claudeAncestor(startPid) {
+  let pid = startPid;
+  for (let hops = 0; hops < 12 && isPid(pid) && pid > 1; hops += 1) {
+    let comm = '';
+    try { comm = fs.readFileSync(`/proc/${pid}/comm`, 'utf8').trim(); } catch { return null; }
+    if (comm === 'claude') return pid;
+    // stat field 4 is ppid; the comm field (2) may contain spaces or parens, so
+    // parse from the LAST ')' rather than splitting the whole line.
+    let stat = '';
+    try { stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8'); } catch { return null; }
+    const tail = stat.slice(stat.lastIndexOf(')') + 1).trim().split(/\s+/);
+    const parent = Number(tail[1]);
+    if (!isPid(parent)) return null;
+    pid = parent;
+  }
+  return null;
+}
+
+/**
+ * The identity the nonce file is keyed on. Exported for tests and diagnostics.
+ * @returns {{key:number, source:'CLAUDE_PID'|'proc-ancestor'|'ppid'}}
+ */
+export function runKey(env = process.env, ppid = process.ppid) {
+  const declared = Number(env.CLAUDE_PID);
+  if (isPid(declared)) return { key: declared, source: 'CLAUDE_PID' };
+  const walked = process.platform === 'linux' ? claudeAncestor(ppid) : null;
+  if (isPid(walked)) return { key: walked, source: 'proc-ancestor' };
+  return { key: ppid, source: 'ppid' };
+}
+
+/** Path of the nonce file for a given key — one per CLI process. */
+export const runFileFor = (home, key) => path.join(home, `run-${key}`);
+
+/**
+ * Read this CLI process's nonce, minting and persisting it on first use.
+ * Returns null when HOME is unusable — the caller then leaves the event
+ * untagged rather than failing.
+ */
+export function runNonce(home, env = process.env, ppid = process.ppid) {
+  if (!home) return null;
+  try {
+    const file = runFileFor(home, runKey(env, ppid).key);
+    try {
+      const existing = fs.readFileSync(file, 'utf8').trim();
+      if (existing) return existing;
+    } catch { /* first hook of this CLI process */ }
+    const minted = randomUUID();
+    // 0600 like the rest of HOME's state (token, log, db).
+    fs.writeFileSync(file, minted, { mode: 0o600 });
+    return minted;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove nonce files whose CLI process is gone. One file per CLI process is
+ * small, but nothing ever cleaned them up: a long-lived HOME accumulates one
+ * per session forever (and, before the keying fix, one per HOOK). A file is
+ * only removed when its pid is provably dead AND it is older than `minAgeMs`,
+ * so a live CLI's nonce is never pulled out from under it and a just-minted
+ * file cannot lose a race with the process that is about to use it.
+ * @returns {number} how many were removed
+ */
+export function pruneRunNonces(home, { minAgeMs = 3_600_000, now = Date.now() } = {}) {
+  if (!home) return 0;
+  let removed = 0;
+  let names;
+  try { names = fs.readdirSync(home); } catch { return 0; }
+  for (const name of names) {
+    const m = /^run-(\d+)$/.exec(name);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    if (!isPid(pid)) continue;
+    const file = path.join(home, name);
+    try {
+      if (now - fs.statSync(file).mtimeMs < minAgeMs) continue;
+      // Alive (or not ours to judge — EPERM means SOMETHING holds the pid): keep.
+      try { process.kill(pid, 0); continue; } catch (err) { if (err?.code !== 'ESRCH') continue; }
+      fs.unlinkSync(file);
+      removed += 1;
+    } catch { /* raced with another prune, or unreadable — leave it */ }
+  }
+  return removed;
+}

--- a/tests/run-nonce.test.mjs
+++ b/tests/run-nonce.test.mjs
@@ -1,0 +1,101 @@
+// tests/run-nonce.test.mjs
+//
+// THE RUN NONCE MUST IDENTIFY THE CLI PROCESS, NOT THE HOOK INVOCATION.
+//
+// BUG-025's guard refuses to tombstone on a SessionEnd whose nonce is not the
+// card's active run — that is what stops a delayed async end from killing a
+// live `claude --resume`. It only works if every hook of ONE CLI process
+// reports the SAME nonce, and a DIFFERENT process reports a different one.
+//
+// The nonce used to be keyed on `process.ppid`. Claude Code runs each hook
+// through a fresh intermediate shell, so that key changed on every single hook:
+// SessionStart stored nonce A, the SessionEnd that followed minted B, and
+// B !== A made EVERY tagged end look stale. Measured on one real session before
+// the fix: 510 nonce files, 510 distinct values, none matching the card's run.
+// Consequences: hook-only sessions never tombstoned on exit, an armed
+// move-to-tmux could never fire, and HOME grew a file per hook.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync, utimesSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pruneRunNonces, runFileFor, runKey, runNonce } from '../scripts/fleetd/run-nonce.mjs';
+
+function home(t) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'fd-runnonce-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }));
+  return dir;
+}
+
+test('every hook of ONE CLI process gets the SAME nonce, whatever its parent shell is', (t) => {
+  const dir = home(t);
+  // Three hooks of one CLI, each spawned under a different throwaway shell —
+  // the exact shape that used to mint three different nonces.
+  const a = runNonce(dir, { CLAUDE_PID: '4242' }, 1001);
+  const b = runNonce(dir, { CLAUDE_PID: '4242' }, 1002);
+  const c = runNonce(dir, { CLAUDE_PID: '4242' }, 1003);
+
+  assert.ok(a, 'a nonce must be minted');
+  assert.equal(a, b, 'a second hook of the same CLI must reuse the nonce');
+  assert.equal(b, c, 'and a third');
+  const files = readdirSync(dir).filter(f => f.startsWith('run-'));
+  assert.deepEqual(files, [`run-4242`],
+    `exactly ONE nonce file per CLI process; got ${JSON.stringify(files)}`);
+});
+
+test('a --resume (new CLI process, same session id) gets a NEW nonce — the guard still works', (t) => {
+  const dir = home(t);
+  const first = runNonce(dir, { CLAUDE_PID: '4242' }, 1001);
+  const resumed = runNonce(dir, { CLAUDE_PID: '9999' }, 1001);
+  assert.notEqual(resumed, first,
+    'a different CLI process must not inherit the previous run nonce, or a delayed '
+    + 'SessionEnd from the dead process would tombstone the live resumed one');
+});
+
+test('CLAUDE_PID is preferred; ppid is only the last-resort fallback', () => {
+  assert.deepEqual(runKey({ CLAUDE_PID: '4242' }, 77), { key: 4242, source: 'CLAUDE_PID' });
+  // Garbage never silently becomes a key.
+  for (const bad of ['', '0', '-3', 'nope', undefined]) {
+    const k = runKey({ CLAUDE_PID: bad }, 77);
+    assert.notEqual(k.source, 'CLAUDE_PID', `CLAUDE_PID=${JSON.stringify(bad)} must be rejected`);
+    assert.ok(k.key > 0, 'a usable key is still produced');
+  }
+});
+
+test('an unusable HOME leaves the event UNTAGGED rather than throwing (fail open)', () => {
+  assert.equal(runNonce('', { CLAUDE_PID: '4242' }, 1), null);
+  assert.equal(runNonce('/proc/nonexistent-and-unwritable', { CLAUDE_PID: '4242' }, 1), null);
+});
+
+test('prune removes nonce files of dead CLIs and never touches a live one', (t) => {
+  const dir = home(t);
+  const old = Date.now() / 1000 - 7200; // two hours ago
+
+  // A live CLI: our own pid, aged so only liveness protects it.
+  const live = runFileFor(dir, process.pid);
+  writeFileSync(live, 'live-nonce', { mode: 0o600 });
+  utimesSync(live, old, old);
+
+  // A dead CLI: a pid that cannot exist.
+  const dead = runFileFor(dir, 4194304);
+  writeFileSync(dead, 'dead-nonce', { mode: 0o600 });
+  utimesSync(dead, old, old);
+
+  // A freshly minted file for a dead pid — too young to touch, because a hook
+  // may be about to read the nonce it just wrote.
+  const fresh = runFileFor(dir, 4194303);
+  writeFileSync(fresh, 'fresh-nonce', { mode: 0o600 });
+
+  const removed = pruneRunNonces(dir);
+
+  assert.equal(removed, 1, 'exactly the aged dead file is collected');
+  assert.ok(existsSync(live), 'a LIVE CLI must keep the nonce its next hook will read');
+  assert.ok(!existsSync(dead), 'an aged file whose pid is gone is collectable');
+  assert.ok(existsSync(fresh), 'a just-minted file is never yanked out from under its process');
+});
+
+test('prune is safe on a missing or empty HOME', () => {
+  assert.equal(pruneRunNonces(''), 0);
+  assert.equal(pruneRunNonces('/definitely/not/a/dir'), 0);
+});


### PR DESCRIPTION
## v0.22.3 — exiting the CLI did nothing, because the board couldn't tell one run from another

Found while trying to use **move to tmux** on a live session: the click armed it, the CLI was exited, and nothing happened — five times. The board's own ticker had been recording the reason all along:

```
⧗ raven-1577 armed for move-to-tmux — exit the CLI to move it
⏭ raven-1577 ignored a delayed SessionEnd from a previous run
```

### Root cause

BUG-025's guard refuses to tombstone on a `SessionEnd` whose nonce isn't the card's active run — that's what stops a delayed async end from killing a live `claude --resume`. The nonce was keyed on **the hook shim's parent pid**, assuming the hook's parent is the CLI. It isn't: Claude Code runs each hook through a fresh intermediate shell, so the key changed on *every hook*.

Measured on one real session before the fix:

```
run-* files:            510
distinct nonce values:  510      ← one per HOOK, all different
card run_id:            428b051b…    ← matched none of them
```

So `SessionStart` stored nonce A, the following `SessionEnd` minted B, and B ≠ A made **every** tagged end look stale.

### Two silent consequences

- **Hook-only sessions never tombstoned on exit** — cards lingered until the silence sweep hours later. (Same mechanism behind a killed spawn reading `"stale async end … ignored"` and then refusing to dismiss.)
- **An armed move-to-tmux could never fire** — `hookSessionEnd` returns at the stale check, 55 lines above the block that consumes the arm. The card stayed armed, nothing moved, no error anywhere.

### The fix

Key the nonce on the CLI process itself. `CLAUDE_PID` is exported by Claude Code and reaches hooks through any intervening shell — verified on this machine: `CLAUDE_PID=26901` is the real `claude` process and is stable across invocations, while the shim's ppid moved `29137 → 29218` between two calls. Fallbacks: `CLAUDE_PID` → nearest `claude` ancestor via `/proc` → the historical ppid. Every failure path still leaves the event untagged (the unconditional-tombstone path) — fail open, never break a session.

A `--resume` is a new process and still gets a **new** nonce, which is exactly what the original guard needs.

Both shims now import **one shared module** instead of each carrying its own copy — duplicated derivations are what let these drift apart to begin with.

Also: **nonce files are finally collected.** Nothing ever removed them, so a long-lived home accumulated one per session forever (one per *hook* before this fix). The retention sweep drops a file only when its pid is provably dead and the file has aged, so a live CLI never loses the nonce its next hook will read.

### Verification

- **6 unit tests**: one nonce across three different ppids (and exactly one file); a different CLI pid gets a new nonce; `CLAUDE_PID` preferred and garbage rejected; fail-open on an unusable home; prune spares live *and* freshly-minted files.
- **End to end** against a scratch daemon, driving the **real shims as separate processes with differing ppids**: the `SessionEnd` now matches and the card tombstones (`col=offline`, `note="session ended (other)"`) with exactly one nonce file — where before it was discarded.
- 91/91 across the hook and retention suites; version contract 9/9 on 0.22.3; payload, release and bundle gates clean.

One caveat stated plainly: I could not get a synthetic negative-control run (the same e2e against a forced-ppid copy) to execute, so the "old code fails this" claim rests on the production evidence above rather than a scripted reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
