### PR TITLE
fix(hooks): stop recursive FileChanged watches (v0.22.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "source": "./",
       "displayName": "Fleet Deck",
       "description": "Localhost fleet board for Claude Code: every session on the machine visible on one board, cross-session file-conflict whispers, and turn-boundary mail between sessions. Zero wrapper, zero model calls in the core. Tested against Claude Code 2.1.206+ (through 2.1.207).",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "author": {
         "name": "Luis Morales"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck",
   "displayName": "Fleet Deck",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Localhost fleet board for Claude Code: every session on the machine visible on one board, cross-session file-conflict whispers, and turn-boundary mail between sessions. Zero wrapper, zero model calls in the core. Tested against Claude Code 2.1.206+ (through 2.1.207).",
   "author": {
     "name": "Luis Morales",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Fleet Deck are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.5] - 2026-08-11
+
+Large repositories could freeze before Claude Code reached the prompt.
+
+### Fixed
+
+- **Fleet Deck no longer recursively watches the entire session directory.**
+  BUG-104 registered the session `cwd` through `watchPaths` so external edits
+  could feed the conflict ledger, but Claude Code recursively traverses that
+  directory before startup completes. In repositories with large `.git` object
+  stores or `node_modules` trees, registration could produce a sustained
+  `FileChanged` storm and wedge the session indefinitely. `SessionStart`,
+  `CwdChanged`, and `FileChanged` no longer emit dynamic watch paths, and the
+  `FileChanged` hook is disabled entirely because exact matcher paths can also
+  name large directories. The daemon also acknowledges cached pre-upgrade
+  `FileChanged` requests without ingesting them, so an old hook cannot keep
+  churning session state and the conflict ledger. Normal `PostToolUse` tracking
+  remains; broad external-change telemetry is deliberately sacrificed because
+  a running session is more important than optional conflict attribution.
+  Existing Claude Code processes that loaded the old watcher must be restarted;
+  `/clear` does not remove a dynamic watch already installed in that process.
+
 ## [0.22.4] - 2026-08-07
 
 A spawned pane exposed Claude Code's own agent view, a second fleet the board

--- a/board/package-lock.json
+++ b/board/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetdeck-board",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetdeck-board",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",

--- a/board/package.json
+++ b/board/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck-board",
   "private": true,
-  "version": "0.22.4",
+  "version": "0.22.5",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/demo/render-smoke-settings.mjs
+++ b/demo/render-smoke-settings.mjs
@@ -53,9 +53,6 @@ const settings = {
     SessionEnd: [
       { hooks: [{ type: 'command', command: hook('SessionEnd'), timeout: 3, async: true }] },
     ],
-    FileChanged: [
-      { hooks: [{ type: 'command', command: hook('FileChanged'), timeout: 3, async: true }] },
-    ],
   },
 };
 

--- a/demo/run-accept-phase3.sh
+++ b/demo/run-accept-phase3.sh
@@ -381,9 +381,6 @@ FLEET_HOOK_SCRIPT="${FLEET_HOOK_SCRIPT:-$WATCH_SCRIPT}"; cat > "$PROJECT_DIR/.cl
     ],
     "SessionEnd": [
       { "hooks": [{ "type": "command", "command": "node \"$FLEET_HOOK_SCRIPT\" SessionEnd", "timeout": 3, "async": true }] }
-    ],
-    "FileChanged": [
-      { "hooks": [{ "type": "command", "command": "node \"$FLEET_HOOK_SCRIPT\" FileChanged", "timeout": 3, "async": true }] }
     ]
   }
 }

--- a/demo/run-accept-plan.sh
+++ b/demo/run-accept-plan.sh
@@ -455,9 +455,6 @@ FLEET_HOOK_SCRIPT="${FLEET_HOOK_SCRIPT:-$WATCH_SCRIPT}"; cat > "$PROJECT_DIR/.cl
     ],
     "SessionEnd": [
       { "hooks": [{ "type": "command", "command": "node \"$FLEET_HOOK_SCRIPT\" SessionEnd", "timeout": 3, "async": true }] }
-    ],
-    "FileChanged": [
-      { "hooks": [{ "type": "command", "command": "node \"$FLEET_HOOK_SCRIPT\" FileChanged", "timeout": 3, "async": true }] }
     ]
   }
 }

--- a/demo/run-accept-spawn.sh
+++ b/demo/run-accept-spawn.sh
@@ -286,9 +286,6 @@ FLEET_HOOK_SCRIPT="${FLEET_HOOK_SCRIPT:-$WATCH_SCRIPT}"; cat > "$PROJECT_DIR/.cl
     ],
     "SessionEnd": [
       { "hooks": [{ "type": "command", "command": "node \"$FLEET_HOOK_SCRIPT\" SessionEnd", "timeout": 3, "async": true }] }
-    ],
-    "FileChanged": [
-      { "hooks": [{ "type": "command", "command": "node \"$FLEET_HOOK_SCRIPT\" FileChanged", "timeout": 3, "async": true }] }
     ]
   }
 }

--- a/demo/run-smoke.sh
+++ b/demo/run-smoke.sh
@@ -270,9 +270,6 @@ cat > "$PROJECT_DIR/.claude/settings.json" <<EOF
     ],
     "SessionEnd": [
       { "hooks": [{ "type": "command", "command": "node \"$FLEET_HOOK_SCRIPT\" SessionEnd", "timeout": 3, "async": true }] }
-    ],
-    "FileChanged": [
-      { "hooks": [{ "type": "command", "command": "node \"$FLEET_HOOK_SCRIPT\" FileChanged", "timeout": 3, "async": true }] }
     ]
   }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "_filechanged": "The FileChanged matcher is the plugin's structural always-on watch list, registered under every supported CLI (BUG-104 — a matcher-less FileChanged registers nothing, so the hook is wired but never fires). Its segments are literal top-level filenames, not regexes: config surfaces (claude|json), env surfaces (envrc|env), fleet decks (fleet|deck), and the 199 scratch pad that keeps the static list non-empty even with a dead hook. Segments must stay inside the exact-match alphabet (letters, digits, _, |) or the harness stops treating the value as a watch list. New-project and late-created files ride SessionStart/CwdChanged watchPaths (scripts/fleet-sessionstart.mjs, scripts/fleet-hook.mjs), which replace the dynamic watch list on every event. tests/filechanged-watch.test.mjs guards the alphabet and the structural segments.",
+  "_filechanged": "FileChanged is intentionally not registered. Claude Code's watcher has no exclusion contract: a dynamic cwd watch traverses .git and node_modules, while exact matcher paths can themselves be large directories. PostToolUse still records writes made through Claude's tools; broad external-edit telemetry stays disabled until Fleet Deck owns an ignore-capable watcher. tests/filechanged-watch.test.mjs guards this contract.",
   "_lockstep": "The 720s timeouts on AskUserQuestion/PermissionRequest/Elicitation are one invariant with scripts/fleet-hook.mjs WATCHDOG_MS (660s) and the daemon hold window (scripts/fleetd/questions.mjs resolveHoldMs, default 600s, clamp ceiling 650s): hold < watchdog < timeout, or a board answer lands on a dead socket. Change all three together.",
   "hooks": {
     "SessionStart": [
@@ -119,19 +119,6 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/fleet-hook.mjs\" SessionEnd",
-            "timeout": 3,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "FileChanged": [
-      {
-        "matcher": "claude|json|envrc|env|fleet|deck|199",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/fleet-hook.mjs\" FileChanged",
             "timeout": 3,
             "async": true
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetdeck",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetdeck",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck",
-  "version": "0.22.4",
-  "description": "Fleet Deck — localhost daemon + board that makes every Claude Code session on a machine visible. Tested against Claude Code 2.1.206.",
+  "version": "0.22.5",
+  "description": "Fleet Deck — localhost daemon + board that makes every Claude Code session on a machine visible. Tested against Claude Code 2.1.206+ (through 2.1.207).",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/scripts/fleet-hook.mjs
+++ b/scripts/fleet-hook.mjs
@@ -13,14 +13,7 @@
 // Design rule (same as fleet-sessionstart.mjs): NEVER break the session. Every
 // failure path is a silent exit 0 with '{}' on stdout, and the per-event
 // watchdog guarantees we are gone before hooks.json's own timeout would fire.
-//
-// BUG-104: this shim also refreshes the dynamic FileChanged watch list.
-// SessionStart (fleet-sessionstart.mjs) seeds hookSpecificOutput.watchPaths
-// with the session cwd; CwdChanged re-pins it when the working directory moves
-// (its watchPaths REPLACE the dynamic list, so an unchanged list must be
-// re-emitted or a `cd` would silently clear every registration), and each
-// delivered FileChanged re-pins it too. The daemon response is forwarded
-// verbatim for every event, with watchPaths merged in for these two.
+
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -84,31 +77,8 @@ async function readStdinRaw() {
   return data;
 }
 
-// Events that refresh the dynamic FileChanged watch list (BUG-104). CwdChanged
-// watchPaths REPLACE the dynamic list, so the shim re-pins the current cwd on
-// both events — a bare daemon '{}' would otherwise wipe it.
-const WATCH_EVENTS = new Set(['CwdChanged', 'FileChanged']);
-function watchPathsFor(raw) {
-  try {
-    const cwd = JSON.parse(raw || '{}')?.cwd;
-    return typeof cwd === 'string' && cwd ? [cwd] : null;
-  } catch { return null; }
-}
-// Fold watchPaths into the daemon's response (it owns every other field — the
-// daemon knows nothing about harness watch registration). Non-JSON daemon
-// output passes through untouched rather than risking a mangled contract.
-function mergeWatchPaths(text, watchPaths) {
-  if (!watchPaths) return text;
-  try {
-    const out = JSON.parse(text || '{}');
-    out.hookSpecificOutput = { ...(out.hookSpecificOutput || {}), hookEventName: EVENT, watchPaths };
-    return JSON.stringify(out);
-  } catch { return text; }
-}
-
 try {
   const raw = await readStdinRaw();
-  const watchPaths = WATCH_EVENTS.has(EVENT) ? watchPathsFor(raw) : null;
   const headers = { 'content-type': 'application/json' };
   if (TOKEN) headers.authorization = `Bearer ${TOKEN}`;
   const ctl = new AbortController();
@@ -122,7 +92,7 @@ try {
     // receives additionalContext / hold decisions. A 401 carries no contract
     // body; emit the fail-open no-op instead.
     const body = res.ok && text ? text : '{}';
-    process.stdout.write(watchPaths ? mergeWatchPaths(body, watchPaths) : body);
+    process.stdout.write(body);
   } finally { clearTimeout(t); }
 } catch { try { process.stdout.write('{}'); } catch { /* gone */ } }
 clearTimeout(watchdog);

--- a/scripts/fleet-sessionstart.mjs
+++ b/scripts/fleet-sessionstart.mjs
@@ -1,20 +1,15 @@
 #!/usr/bin/env node
-// fleet-sessionstart.mjs — the ONLY command hook. Election + spawn + brief +
-// the dynamic FileChanged watch list (BUG-104).
+// fleet-sessionstart.mjs — the ONLY command hook. Election + spawn +
+// registration + brief.
 //
 // Reads the SessionStart hook payload on stdin, makes sure fleetd is up
 // (health check → spawn detached → poll ~3 s), POSTs /hook/SessionStart and
 // prints the daemon-composed roster brief to stdout (SessionStart stdout is
 // added to the session context).
 //
-// It also owns watch registration: hooks.json's FileChanged matcher can only
-// watch literal top-level filenames, so coverage of the files a session will
-// actually touch has to come from hookSpecificOutput.watchPaths. stdout is
-// therefore a single JSON object: the roster brief rides additionalContext and
-// watchPaths registers the session's cwd — the one absolute path that covers
-// every file the session may touch, including files created after startup.
-// fleet-hook.mjs refreshes the same list from CwdChanged, and every delivered
-// FileChanged event re-pins it.
+// FileChanged is deliberately not registered. This hook also emits no dynamic
+// watchPaths: registering the session cwd makes the harness recurse through .git,
+// node_modules, and every other subtree, which can wedge startup in large repos.
 //
 // Design rule #1: this script must NEVER break the session. EVERY failure
 // path is a silent exit 0, and a watchdog guarantees we are gone in ~4 s.
@@ -294,15 +289,10 @@ try {
   // the daemon answers with upgrade lines (which other sessions still run
   // pre-upgrade hooks) so the human hears it from the session that caused it.
   if (replacedVersion) payload.fleet_takeover = replacedVersion;
-  // BUG-104: the FileChanged hook is dead weight without a watch list — a
-  // matcher-less FileChanged registers nothing, and matchers can only name
-  // literal top-level files. SessionStart's hookSpecificOutput.watchPaths is
-  // the dynamic registration channel: hand the harness the session's cwd (the
-  // one absolute path covering everything the session may touch, including
-  // files created after startup). The brief and the warnings move into
-  // additionalContext — SessionStart accepts BOTH plain stdout and JSON, but
-  // only the JSON form carries watchPaths.
-  const watchPaths = [typeof payload.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd()];
+  // BUG-104 registered the entire session cwd as a dynamic watch. Do not emit
+  // watchPaths at all: losing broad external-change telemetry is safer than
+  // recursively traversing a large repository before the prompt is available.
+  // PostToolUse remains the safe source of write/conflict telemetry.
   const context = [];
   if (serverUp) {
     // Cold boot: ensureServer() just minted HOME/token. Refresh before the first
@@ -321,9 +311,7 @@ try {
     }
     if (reg?.brief) context.push(reg.brief);
   }
-  const hookSpecificOutput = { hookEventName: 'SessionStart', watchPaths };
-  if (context.length) hookSpecificOutput.additionalContext = context.join('');
-  process.stdout.write(JSON.stringify({ hookSpecificOutput }));
+  process.stdout.write(context.join(''));
 } catch { /* no fleet, no drama */ }
 clearTimeout(watchdog);
 process.exit(0);

--- a/scripts/fleetd/events.mjs
+++ b/scripts/fleetd/events.mjs
@@ -316,8 +316,7 @@ export function createEvents(ctx) {
         break;
       }
       case 'CwdChanged':
-        // BUG-104: telemetry only — the watch-list refresh for the new cwd is
-        // emitted by the hook shim (fleet-hook.mjs), not by this response.
+        // Telemetry only — FileChanged watching is deliberately disabled.
         set.note = `cwd → ${path.basename(ev.cwd || '') || 'cwd changed'}`;
         break;
       case 'Notification': {

--- a/scripts/fleetd/fleetd.bundle.mjs
+++ b/scripts/fleetd/fleetd.bundle.mjs
@@ -13851,10 +13851,10 @@ function createHttp(core2, {
     Stop: (ev) => core2.hookStop(ev),
     SessionEnd: (ev) => core2.hookSessionEnd(ev),
     Notification: (ev) => (core2.applyEvent({ ...ev, hook_event_name: "Notification" }), {}),
-    FileChanged: (ev) => (core2.applyEvent({ ...ev, hook_event_name: "FileChanged" }), {}),
-    // BUG-104: the shim emits this event's watchPaths itself (fleet-hook.mjs);
-    // the daemon side is pure telemetry — one note so a `cd` is visible in the
-    // session's event log.
+    // Older cached plugin hooks can keep emitting FileChanged after an upgrade.
+    // Acknowledge them without touching session state or the conflict ledger.
+    FileChanged: () => ({}),
+    // CwdChanged remains pure telemetry for the session event log.
     CwdChanged: (ev) => (core2.applyEvent({ ...ev, hook_event_name: "CwdChanged" }), {})
   };
   function holdHook(res, ev, name) {

--- a/scripts/fleetd/http.mjs
+++ b/scripts/fleetd/http.mjs
@@ -603,10 +603,10 @@ export function createHttp(core, {
     Stop: ev => core.hookStop(ev),
     SessionEnd: ev => core.hookSessionEnd(ev),
     Notification: ev => (core.applyEvent({ ...ev, hook_event_name: 'Notification' }), {}),
-    FileChanged: ev => (core.applyEvent({ ...ev, hook_event_name: 'FileChanged' }), {}),
-    // BUG-104: the shim emits this event's watchPaths itself (fleet-hook.mjs);
-    // the daemon side is pure telemetry — one note so a `cd` is visible in the
-    // session's event log.
+    // Older cached plugin hooks can keep emitting FileChanged after an upgrade.
+    // Acknowledge them without touching session state or the conflict ledger.
+    FileChanged: () => ({}),
+    // CwdChanged remains pure telemetry for the session event log.
     CwdChanged: ev => (core.applyEvent({ ...ev, hook_event_name: 'CwdChanged' }), {}),
   };
 

--- a/tests/filechanged-watch.test.mjs
+++ b/tests/filechanged-watch.test.mjs
@@ -1,18 +1,9 @@
 // tests/filechanged-watch.test.mjs — BUG-104 regression coverage.
 //
-// The defect: hooks.json registered a FileChanged hook with NO matcher and
-// nothing emitted hookSpecificOutput.watchPaths, so the plugin established an
-// empty watch list — an external or shell-side edit to a repository file never
-// reached fleet-hook.mjs, and the recent-file ledger/conflict radar stayed
-// blind to it. The fix wires the harness's dynamic registration:
-//   - SessionStart (fleet-sessionstart.mjs) prints the SessionStart JSON
-//     contract with watchPaths = [cwd] and the roster brief in
-//     additionalContext (previously plain stdout, which cannot carry watchPaths);
-//   - fleet-hook.mjs re-pins watchPaths from CwdChanged (whose watchPaths
-//     REPLACE the dynamic list) and from every delivered FileChanged;
-//   - the daemon routes /hook/CwdChanged like FileChanged (telemetry only);
-//   - hooks.json's FileChanged matcher is a literal, non-empty static watch
-//     list, so the plugin never establishes an empty registration again.
+// BUG-104 fixed a dead FileChanged hook by adding static and dynamic watches.
+// Both can recursively traverse directories, so FileChanged is now disabled,
+// legacy requests are ignored, and SessionStart emits no dynamic watchPaths.
+// CwdChanged remains telemetry-only.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -21,15 +12,20 @@ import { spawn } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { startDaemon } from './helpers/daemon.mjs';
+import { REPO_ROOT, startDaemon } from './helpers/daemon.mjs';
 import { getJson } from './helpers/http.mjs';
+import { scaleMs } from './helpers/wait.mjs';
 
-const HERE = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(HERE, '..');
 const HOOKS_JSON = path.join(REPO_ROOT, 'hooks/hooks.json');
 const SESSIONSTART = path.join(REPO_ROOT, 'scripts/fleet-sessionstart.mjs');
 const SHIM = path.join(REPO_ROOT, 'scripts/fleet-hook.mjs');
+const DEMO_HOOK_TABLES = [
+  'demo/render-smoke-settings.mjs',
+  'demo/run-smoke.sh',
+  'demo/run-accept-plan.sh',
+  'demo/run-accept-phase3.sh',
+  'demo/run-accept-spawn.sh',
+];
 
 function scratch(t, prefix = 'fleetdeck-cwd-') {
   const dir = mkdtempSync(path.join(tmpdir(), prefix));
@@ -46,88 +42,83 @@ function runHook(script, event, payload, env = {}, timeoutMs = 8000) {
   child.stdout.on('data', d => { stdout += d; });
   child.stdin.on('error', () => {}); // EPIPE if the hook exits early
   child.stdin.end(JSON.stringify(payload));
-  return Promise.race([
-    new Promise((resolve, reject) => {
-      child.once('error', reject);
-      child.once('exit', code => resolve({ code, stdout }));
-    }),
-    new Promise((_, reject) => setTimeout(() => { child.kill('SIGKILL'); reject(new Error('hook did not exit in time')); }, timeoutMs)),
-  ]);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('hook did not exit in time'));
+    }, scaleMs(timeoutMs));
+    child.once('error', error => { clearTimeout(timer); reject(error); });
+    child.once('exit', code => { clearTimeout(timer); resolve({ code, stdout }); });
+  });
 }
 
-test('hooks.json FileChanged has a matcher that cannot silently rot', () => {
+test('production and demo hook tables do not register FileChanged', () => {
   const hooks = JSON.parse(readFileSync(HOOKS_JSON, 'utf8'));
-  const matcher = hooks?.hooks?.FileChanged?.[0]?.matcher;
-  assert.ok(typeof matcher === 'string' && matcher.length > 0,
-    'a matcher-less FileChanged registers NO watched files (BUG-104)');
-  // FileChanged matchers are literal filenames, not regexes: every segment
-  // must stay inside the narrow exact-match alphabet (letters, digits, _, |)
-  // or the harness stops treating it as a watch list.
-  assert.match(matcher, /^[A-Za-z0-9_|]+$/,
-    'a FileChanged matcher outside the exact-match alphabet registers no literal watches');
-  // The plugin's own structural surfaces must always be watched, even with a
-  // dead hook: Claude config files, env files, and fleet decks.
-  for (const segment of ['claude', 'json', 'envrc', 'env', 'fleet', 'deck']) {
-    assert.ok(matcher.split('|').includes(segment),
-      `the static watch list must keep the '${segment}' surface`);
+  assert.equal(Object.hasOwn(hooks.hooks, 'FileChanged'), false,
+    'production must not start Claude Code\'s recursive file watcher');
+  for (const rel of DEMO_HOOK_TABLES) {
+    assert.doesNotMatch(readFileSync(path.join(REPO_ROOT, rel), 'utf8'), /FileChanged["']?\s*:/,
+      `${rel} must not register FileChanged`);
   }
 });
 
-test('fleet-sessionstart prints the SessionStart JSON contract with watchPaths and the brief', async (t) => {
+test('legacy FileChanged hook requests are accepted without ingesting telemetry', async (t) => {
   const daemon = await startDaemon();
   const cwd = scratch(t);
   t.after(() => daemon.stop());
   const sid = randomUUID();
 
-  // Drive the REAL SessionStart hook end to end: it must find the daemon,
-  // register the session, and print valid JSON whose hookSpecificOutput both
-  // registers the cwd watch and still delivers the roster brief.
+  const { code, stdout } = await runHook(SHIM, 'FileChanged',
+    { session_id: sid, hook_event_name: 'FileChanged', cwd, file_path: path.join(cwd, 'large-tree') },
+    { FLEETDECK_HOME: daemon.home, FLEETDECK_PORT: String(daemon.port) });
+  assert.equal(code, 0);
+  assert.deepEqual(JSON.parse(stdout), {});
+
+  const state = (await getJson(`${daemon.baseUrl}/state`)).json;
+  assert.equal(state.sessions.some(s => s.session_id === sid), false,
+    'legacy FileChanged traffic must not create or mutate a session card');
+});
+
+test('fleet-sessionstart returns plain context without structured watch output', async (t) => {
+  const daemon = await startDaemon();
+  const cwd = scratch(t);
+  t.after(() => daemon.stop());
+  const sid = randomUUID();
+
+  // Drive the real SessionStart hook end to end: it must register the session
+  // and deliver the roster brief without handing the cwd to the file watcher.
   const { code, stdout } = await runHook(SESSIONSTART, null,
     { session_id: sid, hook_event_name: 'SessionStart', cwd, source: 'startup' },
     { FLEETDECK_HOME: daemon.home, FLEETDECK_PORT: String(daemon.port) });
   assert.equal(code, 0);
 
-  const out = JSON.parse(stdout); // throws if the hook fell back to plain-text stdout
-  const hso = out.hookSpecificOutput;
-  assert.ok(hso, 'SessionStart must print hookSpecificOutput JSON, not bare brief text');
-  assert.equal(hso.hookEventName, 'SessionStart');
-  assert.deepEqual(hso.watchPaths, [cwd],
-    'SessionStart must register the session cwd so FileChanged can fire at all');
-  assert.match(hso.additionalContext ?? '', /fleet/i,
-    'the roster brief must survive the move into additionalContext');
+  assert.match(stdout, /fleet/i, 'SessionStart must still deliver the roster brief');
+  assert.throws(() => JSON.parse(stdout),
+    'SessionStart must use plain stdout, not structured hook output that can register watches');
 
   const state = (await getJson(`${daemon.baseUrl}/state`)).json;
   assert.ok(state.sessions.some(s => s.session_id === sid),
     'the hook must still register the session with the daemon');
 });
 
-test('fleet-hook re-pins watchPaths on CwdChanged and FileChanged', async (t) => {
+test('fleet-hook forwards CwdChanged telemetry without dynamic watchPaths', async (t) => {
   const daemon = await startDaemon();
   const cwd = scratch(t);
   t.after(() => daemon.stop());
   const sid = randomUUID();
   const env = { FLEETDECK_HOME: daemon.home, FLEETDECK_PORT: String(daemon.port) };
 
-  // CwdChanged watchPaths REPLACE the dynamic list — a bare daemon '{}'
-  // forwarded verbatim would silently clear every registration after a `cd`.
+  // CwdChanged remains visible to the daemon, but its hook response must not
+  // introduce a dynamic file watch.
   const cwdRes = await runHook(SHIM, 'CwdChanged',
     { session_id: sid, hook_event_name: 'CwdChanged', cwd }, env);
   assert.equal(cwdRes.code, 0);
-  assert.deepEqual(JSON.parse(cwdRes.stdout).hookSpecificOutput?.watchPaths, [cwd],
-    'CwdChanged must re-pin the dynamic watch list, not forward a bare {}');
+  assert.equal(JSON.parse(cwdRes.stdout).hookSpecificOutput?.watchPaths, undefined,
+    'CwdChanged must not emit dynamic watchPaths');
 
-  // Every delivered FileChanged re-pins the list too, so the registration
-  // survives whatever else replaced it.
-  const file = path.join(cwd, 'notes.txt');
-  const fcRes = await runHook(SHIM, 'FileChanged',
-    { session_id: sid, hook_event_name: 'FileChanged', cwd, file_path: file, event: 'change' }, env);
-  assert.equal(fcRes.code, 0);
-  assert.deepEqual(JSON.parse(fcRes.stdout).hookSpecificOutput?.watchPaths, [cwd],
-    'FileChanged must re-pin the dynamic watch list');
-
-  // Telemetry: the daemon saw both events (the FileChanged fed the ledger).
+  // Telemetry: the daemon saw the cwd change.
   const state = (await getJson(`${daemon.baseUrl}/state`)).json;
   const card = state.sessions.find(s => s.session_id === sid);
   assert.ok(card, 'hook events through the shim must reach the daemon');
-  assert.equal(card.note, 'changed notes.txt');
+  assert.equal(card.note, `cwd → ${path.basename(cwd)}`);
 });

--- a/tests/smoke-settings.test.mjs
+++ b/tests/smoke-settings.test.mjs
@@ -57,7 +57,7 @@ test('smoke settings.json preserves the hook table (events, matchers, timeouts)'
   assert.deepEqual(Object.keys(settings.hooks), [
     'SessionStart', 'UserPromptSubmit', 'PostToolUse', 'PreToolUse',
     'PermissionRequest', 'Elicitation', 'Notification', 'Stop',
-    'SessionEnd', 'FileChanged',
+    'SessionEnd',
   ]);
   assert.equal(settings.hooks.PostToolUse[0].matcher, 'Edit|Write|MultiEdit|NotebookEdit|Bash');
   assert.equal(settings.hooks.PreToolUse[0].matcher, 'AskUserQuestion');


### PR DESCRIPTION
## Summary

- remove `FileChanged` registration from production and demo hook tables
- stop `SessionStart`, `CwdChanged`, and legacy `FileChanged` responses from installing dynamic `watchPaths`
- acknowledge cached pre-upgrade `FileChanged` requests without mutating session state or the conflict ledger
- add regression coverage, rebuild the daemon bundle, and bump all release metadata to `0.22.5`

## Why

Claude Code recursively traverses registered watch directories before startup completes. Watching an entire repository can produce a sustained `FileChanged` storm over large `.git` stores or `node_modules` trees and wedge the session before the prompt appears.

## Validation

- `node scripts/check-release-version.mjs`
- `node --check scripts/fleetd/http.mjs && node --check scripts/fleet-hook.mjs && node --check scripts/fleet-sessionstart.mjs`
- `node --test --test-concurrency=1 --test-timeout=300000 tests/filechanged-watch.test.mjs tests/smoke-settings.test.mjs` — 6 passed
- focused rerun of the previously port-collided adopt case — passed
- `env -u FLEETDECK_BIND node --test --test-concurrency=1 --test-timeout=300000 tests/hook-auth.test.mjs tests/loopback-gates.test.mjs` — 25 passed
- `npm run bundle`
- full clean-environment suite delegated to PR CI because Fleet Deck is actively serving a remote session on this machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
