### PR TITLE
fix(service): recognize npm-distributed Bun runtime

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "source": "./",
       "displayName": "Fleet Deck",
       "description": "Localhost fleet board for Claude Code, guarded by a release-bound compatibility policy.",
-      "version": "0.23.4",
+      "version": "0.23.5",
       "author": {
         "name": "Luis Morales"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck",
   "displayName": "Fleet Deck",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "Localhost fleet board for Claude Code, guarded by a release-bound compatibility policy.",
   "author": {
     "name": "Luis Morales",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Fleet Deck are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.5] - 2026-08-18
+
+### Fixed
+
+- **Coder's managed daemon started successfully but was rejected as an
+  unverified port owner.** Bun's official npm package names its Linux executable
+  `bun.exe`; Fleet Deck's strict process-identity allowlist recognized only the
+  native install name `bun`. Both official Bun executable names now verify the
+  same exact `fleetdeck.mjs serve` argv shape, while every other CLI verb and
+  runtime name remains rejected.
+
 ## [0.23.4] - 2026-08-18
 
 Interactive Claude hooks are silent and fail-open for ordinary or unsupported

--- a/bin/fleetdeck.mjs
+++ b/bin/fleetdeck.mjs
@@ -68,19 +68,20 @@ function pidIsLive(pid) {
     return errCode(err2) !== "ESRCH";
   }
 }
+function fleetdProcessIdentity(executable, argv) {
+  const runtimeLike = /^(?:node|nodejs|bun(?:\.exe)?|fleetd)$/i.test(executable);
+  const fleetdScript = argv.some((arg) => /(?:^|[/\\])fleetd(?:\.bundle)?\.(?:mjs|ts)$/.test(arg));
+  const fleetdeckServe = argv.some(
+    (arg, index) => /(?:^|[/\\])fleetdeck\.(?:mjs|ts)$/.test(arg) && argv[index + 1] === "serve"
+  );
+  return runtimeLike && (fleetdScript || fleetdeckServe);
+}
 function livePidLooksLikeFleetd(pid) {
   if (process.platform !== "linux") return true;
   try {
     const executable = path.basename(fs.readlinkSync(`/proc/${pid}/exe`)).replace(/ \(deleted\)$/, "");
     const argv = fs.readFileSync(`/proc/${pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
-    const runtimeLike = /^(?:node|nodejs|bun|fleetd)$/i.test(executable);
-    const fleetdScript = argv.some(
-      (arg) => /(?:^|[/\\])fleetd(?:\.bundle)?\.(?:mjs|ts)$/.test(arg)
-    );
-    const fleetdeckServe = argv.some(
-      (arg, index) => /(?:^|[/\\])fleetdeck\.(?:mjs|ts)$/.test(arg) && argv[index + 1] === "serve"
-    );
-    return runtimeLike && (fleetdScript || fleetdeckServe);
+    return fleetdProcessIdentity(executable, argv);
   } catch (err2) {
     return errCode(err2) !== "ENOENT";
   }

--- a/board/package.json
+++ b/board/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetdeck-board",
   "private": true,
-  "version": "0.23.4",
+  "version": "0.23.5",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/docs/CODER.md
+++ b/docs/CODER.md
@@ -29,7 +29,7 @@ resource "coder_script" "fleetdeck" {
       set -e
       # Pin this deliberately. For a fleet rollout, use the immutable runtime
       # pattern below instead of updating a live global install in place.
-      npm install -g fleetdeck@0.23.4
+      npm install -g fleetdeck@0.23.5
 
       # A named coder_app's hostname is <slug>--<workspace>--<owner> — the agent
       # name appears only in raw-PORT app hostnames (see "The exact hostname" below).
@@ -263,7 +263,7 @@ runtime compatibility check passes. Do not rely on an image-baked copy when the 
 `~/.claude`, because that mount hides the image layer:
 
 ```sh
-FLEETDECK_VERSION=0.23.4
+FLEETDECK_VERSION=0.23.5
 claude plugin marketplace add "lacion/fleet-deck@v$FLEETDECK_VERSION" --scope user
 claude plugin install fleetdeck@fleetdeck
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetdeck",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "Fleet Deck — localhost daemon + board for Claude Code, guarded by a release-bound compatibility policy.",
   "type": "module",
   "license": "MIT",

--- a/scripts/fleet-hook.mjs
+++ b/scripts/fleet-hook.mjs
@@ -104,7 +104,7 @@ var compatibility_default = {
 // package.json
 var package_default = {
   name: "fleetdeck",
-  version: "0.23.4",
+  version: "0.23.5",
   description: "Fleet Deck \u2014 localhost daemon + board for Claude Code, guarded by a release-bound compatibility policy.",
   type: "module",
   license: "MIT",

--- a/scripts/fleet-sessionstart.mjs
+++ b/scripts/fleet-sessionstart.mjs
@@ -129,19 +129,20 @@ function pidIsLive(pid) {
     return errCode(err) !== "ESRCH";
   }
 }
+function fleetdProcessIdentity(executable, argv) {
+  const runtimeLike = /^(?:node|nodejs|bun(?:\.exe)?|fleetd)$/i.test(executable);
+  const fleetdScript = argv.some((arg) => /(?:^|[/\\])fleetd(?:\.bundle)?\.(?:mjs|ts)$/.test(arg));
+  const fleetdeckServe = argv.some(
+    (arg, index) => /(?:^|[/\\])fleetdeck\.(?:mjs|ts)$/.test(arg) && argv[index + 1] === "serve"
+  );
+  return runtimeLike && (fleetdScript || fleetdeckServe);
+}
 function livePidLooksLikeFleetd(pid) {
   if (process.platform !== "linux") return true;
   try {
     const executable = path2.basename(fs2.readlinkSync(`/proc/${pid}/exe`)).replace(/ \(deleted\)$/, "");
     const argv = fs2.readFileSync(`/proc/${pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
-    const runtimeLike = /^(?:node|nodejs|bun|fleetd)$/i.test(executable);
-    const fleetdScript = argv.some(
-      (arg) => /(?:^|[/\\])fleetd(?:\.bundle)?\.(?:mjs|ts)$/.test(arg)
-    );
-    const fleetdeckServe = argv.some(
-      (arg, index) => /(?:^|[/\\])fleetdeck\.(?:mjs|ts)$/.test(arg) && argv[index + 1] === "serve"
-    );
-    return runtimeLike && (fleetdScript || fleetdeckServe);
+    return fleetdProcessIdentity(executable, argv);
   } catch (err) {
     return errCode(err) !== "ENOENT";
   }
@@ -294,7 +295,7 @@ var compatibility_default = {
 // package.json
 var package_default = {
   name: "fleetdeck",
-  version: "0.23.4",
+  version: "0.23.5",
   description: "Fleet Deck \u2014 localhost daemon + board for Claude Code, guarded by a release-bound compatibility policy.",
   type: "module",
   license: "MIT",

--- a/scripts/fleet-watch.mjs
+++ b/scripts/fleet-watch.mjs
@@ -56,7 +56,7 @@ var compatibility_default = {
 // package.json
 var package_default = {
   name: "fleetdeck",
-  version: "0.23.4",
+  version: "0.23.5",
   description: "Fleet Deck \u2014 localhost daemon + board for Claude Code, guarded by a release-bound compatibility policy.",
   type: "module",
   license: "MIT",

--- a/src/daemon/fleetd.bundle.mjs
+++ b/src/daemon/fleetd.bundle.mjs
@@ -13917,19 +13917,20 @@ function pidIsLive(pid) {
     return errCode(err) !== "ESRCH";
   }
 }
+function fleetdProcessIdentity(executable, argv) {
+  const runtimeLike = /^(?:node|nodejs|bun(?:\.exe)?|fleetd)$/i.test(executable);
+  const fleetdScript = argv.some((arg) => /(?:^|[/\\])fleetd(?:\.bundle)?\.(?:mjs|ts)$/.test(arg));
+  const fleetdeckServe = argv.some(
+    (arg, index) => /(?:^|[/\\])fleetdeck\.(?:mjs|ts)$/.test(arg) && argv[index + 1] === "serve"
+  );
+  return runtimeLike && (fleetdScript || fleetdeckServe);
+}
 function livePidLooksLikeFleetd(pid) {
   if (process.platform !== "linux") return true;
   try {
     const executable = path17.basename(fs16.readlinkSync(`/proc/${pid}/exe`)).replace(/ \(deleted\)$/, "");
     const argv = fs16.readFileSync(`/proc/${pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
-    const runtimeLike = /^(?:node|nodejs|bun|fleetd)$/i.test(executable);
-    const fleetdScript = argv.some(
-      (arg) => /(?:^|[/\\])fleetd(?:\.bundle)?\.(?:mjs|ts)$/.test(arg)
-    );
-    const fleetdeckServe = argv.some(
-      (arg, index) => /(?:^|[/\\])fleetdeck\.(?:mjs|ts)$/.test(arg) && argv[index + 1] === "serve"
-    );
-    return runtimeLike && (fleetdScript || fleetdeckServe);
+    return fleetdProcessIdentity(executable, argv);
   } catch (err) {
     return errCode(err) !== "ENOENT";
   }

--- a/src/daemon/takeover.ts
+++ b/src/daemon/takeover.ts
@@ -75,6 +75,27 @@ function pidIsLive(pid: number): boolean {
   }
 }
 
+function fleetdProcessIdentity(executable: string, argv: string[]): boolean {
+  // Bun's official npm package names its Linux binary `bun.exe` even though it
+  // is a native ELF executable. Coder installs that package through nvm, so the
+  // exact production process uses `.../node_modules/bun/bin/bun.exe` with
+  // `.../fleetdeck.mjs serve`. Keep the runtime allowlist exact while accepting
+  // both official Bun distribution names.
+  const runtimeLike = /^(?:node|nodejs|bun(?:\.exe)?|fleetd)$/i.test(executable);
+  // Match every name the daemon boots under: the production bundle
+  // (fleetd.bundle.mjs), the TypeScript source on a full checkout (fleetd.ts,
+  // run via Bun's native type-stripping), and the legacy fleetd.mjs. The
+  // standalone service intentionally stays in the CLI process while `serve`
+  // dynamically imports the bundle, so its Linux argv is
+  // `bun .../bin/fleetdeck.mjs serve`; require the adjacent `serve` verb so a
+  // harmless `fleetdeck status` process can never satisfy the ownership gate.
+  const fleetdScript = argv.some((arg) => /(?:^|[/\\])fleetd(?:\.bundle)?\.(?:mjs|ts)$/.test(arg));
+  const fleetdeckServe = argv.some(
+    (arg, index) => /(?:^|[/\\])fleetdeck\.(?:mjs|ts)$/.test(arg) && argv[index + 1] === 'serve',
+  );
+  return runtimeLike && (fleetdScript || fleetdeckServe);
+}
+
 function livePidLooksLikeFleetd(pid: number): boolean {
   if (process.platform !== 'linux') return true;
   try {
@@ -82,7 +103,7 @@ function livePidLooksLikeFleetd(pid: number): boolean {
     // identity: Node 24 names it `MainThread` instead of `node`. Resolve the
     // executable symlink so upgrades cannot make a live fleetd look recycled.
     // The dual node:sqlite⇔bun:sqlite seam means a fleetd may legitimately run
-    // under bun (basename `bun`) as well as node — accept either runtime.
+    // under Bun (native install `bun`, npm install `bun.exe`) as well as Node.
     const executable = path
       .basename(fs.readlinkSync(`/proc/${pid}/exe`))
       .replace(/ \(deleted\)$/, '');
@@ -91,21 +112,7 @@ function livePidLooksLikeFleetd(pid: number): boolean {
       .toString('utf8')
       .split('\0')
       .filter(Boolean);
-    const runtimeLike = /^(?:node|nodejs|bun|fleetd)$/i.test(executable);
-    // Match every name the daemon boots under: the production bundle
-    // (fleetd.bundle.mjs), the TypeScript source on a full checkout (fleetd.ts,
-    // run via Bun's native type-stripping), and the legacy fleetd.mjs. The
-    // standalone service intentionally stays in the CLI process while `serve`
-    // dynamically imports the bundle, so its Linux argv is
-    // `bun .../bin/fleetdeck.mjs serve`; require the adjacent `serve` verb so a
-    // harmless `fleetdeck status` process can never satisfy the ownership gate.
-    const fleetdScript = argv.some((arg) =>
-      /(?:^|[/\\])fleetd(?:\.bundle)?\.(?:mjs|ts)$/.test(arg),
-    );
-    const fleetdeckServe = argv.some(
-      (arg, index) => /(?:^|[/\\])fleetdeck\.(?:mjs|ts)$/.test(arg) && argv[index + 1] === 'serve',
-    );
-    return runtimeLike && (fleetdScript || fleetdeckServe);
+    return fleetdProcessIdentity(executable, argv);
   } catch (err) {
     // WHY ENOENT is decisive: the PID died after kill(0), so it no longer owns
     // HOME. Permission and transient I/O failures are not decisive; retaining
@@ -114,7 +121,7 @@ function livePidLooksLikeFleetd(pid: number): boolean {
   }
 }
 
-export { pidRecord, pidIsLive, livePidLooksLikeFleetd };
+export { pidRecord, pidIsLive, fleetdProcessIdentity, livePidLooksLikeFleetd };
 
 // --------------------------------------------------------------------- semver
 // Full SemVer precedence over major.minor.patch PLUS prerelease identifiers

--- a/tests/takeover.test.ts
+++ b/tests/takeover.test.ts
@@ -39,6 +39,7 @@ import { loadFixture } from './helpers/fixtures.ts';
 import { scaleMs, waitUntil } from './helpers/wait.ts';
 import {
   compareSemver,
+  fleetdProcessIdentity,
   parseSemver,
   pidRecord,
   replacementMatches,
@@ -82,6 +83,33 @@ function mustParse(input: string): NonNullable<ReturnType<typeof parseSemver>> {
   assert.ok(parsed, `parseSemver(${input}) must parse`);
   return parsed;
 }
+
+test('fleetd process identity accepts both official Bun executable names only for serve', () => {
+  const bunExe = '/home/coder/.nvm/versions/node/v24/lib/node_modules/bun/bin/bun.exe';
+  const fleetdeckEntry =
+    '/home/coder/.fleetdeck/runtimes/0.23.5/node_modules/fleetdeck/bin/fleetdeck.mjs';
+  const serveArgv = [bunExe, fleetdeckEntry, 'serve'];
+  assert.equal(
+    fleetdProcessIdentity('bun.exe', serveArgv),
+    true,
+    "Bun's npm-distributed Linux executable must verify the managed Coder daemon",
+  );
+  assert.equal(
+    fleetdProcessIdentity('bun', [bunExe.replace(/bun\.exe$/, 'bun'), fleetdeckEntry, 'serve']),
+    true,
+    'the native Bun distribution remains accepted',
+  );
+  assert.equal(
+    fleetdProcessIdentity('bun.exe', [bunExe, fleetdeckEntry, 'status']),
+    false,
+    'accepting bun.exe must not authorize another FleetDeck CLI verb',
+  );
+  assert.equal(
+    fleetdProcessIdentity('bunx', serveArgv),
+    false,
+    'runtime names outside the exact allowlist remain rejected',
+  );
+});
 
 function scratchDir(t: TestContext): string {
   const d = mkdtempSync(path.join(tmpdir(), 'fleetdeck-cwd-'));


### PR DESCRIPTION
## Summary

- accept the official npm Bun executable name (`bun.exe`) in the strict Linux daemon identity gate
- retain the exact `fleetdeck.mjs serve` argv requirement and reject other CLI verbs/runtime names
- bump FleetDeck to 0.23.5 and rebuild generated daemon, CLI, and hook bundles

## Incident proof

Coder launched the healthy managed daemon as `.../node_modules/bun/bin/bun.exe .../fleetdeck.mjs serve`; 0.23.4 rejected that responder as unverified, left hooks inactive, and produced a board 502.

## Verification

- `bun run test`: 1202 pass, 1 platform skip, 0 fail
- `bun run test:bundle`: 1193 pass, 10 documented bundle/platform skips, 0 fail
- npm-distributed `bun@1.3.14` Linux container: service install/start/status/stop passes and `/proc/<pid>/exe` is `bun.exe`
- typecheck, Biome, generated artifact rebuild, `npm pack --dry-run`, and `git diff --check` pass